### PR TITLE
Use integer division and simplify integer packing/unpacking

### DIFF
--- a/lxa_iobus/node.py
+++ b/lxa_iobus/node.py
@@ -365,7 +365,7 @@ class LxaNode:
         if 0x2101 in protocols:
             channel_count = await self.sdo_read(0x2101, 0)
 
-            channel_count = int(array2int(channel_count)/2)
+            channel_count = array2int(channel_count) // 2
 
             for i in range(channel_count):
                 channel = Input(self.address, i, self)
@@ -376,7 +376,7 @@ class LxaNode:
         # Output
         if 0x2100 in protocols:
             channel_count = await self.sdo_read(0x2100, 0)
-            channel_count = int(array2int(channel_count)/2)
+            channel_count = array2int(channel_count) // 2
 
             for i in range(channel_count):
                 channel = Output(self.address, i, self)
@@ -387,7 +387,7 @@ class LxaNode:
         # ADCs
         if 0x2adc in protocols:
             channel_count = await self.sdo_read(0x2adc, 0)
-            channel_count = int(array2int(channel_count))
+            channel_count = array2int(channel_count)
 
             for i in range(channel_count):
                 channel = ADC(self.address, i, self)

--- a/lxa_iobus/node_input.py
+++ b/lxa_iobus/node_input.py
@@ -1,6 +1,6 @@
 import struct
 
-from lxa_iobus.utils import array2int, int2array4
+from lxa_iobus.utils import array2int, int2array
 
 
 class Input:
@@ -39,7 +39,7 @@ class Output(Input):
 
     async def write(self, mask, data):
         self.output_state = (self.output_state & (~mask)) | (data & mask)
-        data = int2array4(((mask & 0xffff) << 16) | (data & 0xffff))
+        data = int2array(((mask & 0xffff) << 16) | (data & 0xffff))
         data = bytearray(data)
 
         await self.node.sdo_write(self.INDEX, (self.channel*2+2), data)

--- a/lxa_iobus/utils.py
+++ b/lxa_iobus/utils.py
@@ -1,16 +1,6 @@
 def array2int(a):
-    out = 0
-
-    for i in range(len(a)):
-        out |= a[i] << (i*8)
-
-    return out
+    return sum((b << (8 * i)) for i, b in enumerate(a))
 
 
-def int2array4(c):
-    out = [0]*4
-
-    for i in range(4):
-        out[i] = 0xff & (c >> (i*8))
-
-    return out
+def int2array(c, octets=4):
+    return list(((c >> (i * 8)) & 0xff) for i in range(octets))


### PR DESCRIPTION
The current code uses floating point division and casting to int, this is more nicely done using integer divisions.
While at it I've also streamlined the integer packing/unpacking utils.

Please consider merging the `lgo/next` branch instead of these individual PRs.