### PR TITLE
systemd/contrib: Update systemd-units

### DIFF
--- a/contrib/systemd/lxa-iobus.service
+++ b/contrib/systemd/lxa-iobus.service
@@ -1,15 +1,23 @@
 [Unit]
 Description=LXA iobus Server
+After=network.target
 
 [Service]
 Type=simple
 ExecStartPre=/usr/bin/mkdir -p /var/cache/lxa-iobus
-ExecStart=/usr/bin/lxa-iobus-server -l WARN --firmware-directory /var/cache/lxa-iobus --host "::" can0_iobus
+ExecStartPre=/usr/bin/ip link set can0_iobus down
+
+# TODO: Update CAN-timings depending on your hardware!
+ExecStartPre=/usr/bin/ip link set can0_iobus type can tq 500 prop-seg 9 phase-seg1 5 phase-seg2 5 sjw 4
+
+ExecStartPre=/usr/bin/ip link set can0_iobus up
+
+# TODO: Update path to venv
+ExecStart=/usr/venvs/lxa-iobus/bin/lxa-iobus-server -l WARN --lss-address-cache-file /var/cache/lxa-iobus/lss-cache --host "*" can0_iobus
+
 Environment="PYTHONUNBUFFERED=1"
 Restart=on-failure
-RestartForceExitStatus=100
 RestartSec=30
 
-
 [Install]
-WantedBy=netowrk.target
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR is an alternative to https://github.com/linux-automation/lxa-iobus/pull/22 .

This is our most recent state of systemd units.

lxa-iobus.service:
* Now uses the lss-address-cache and does disable the
  custom-firmware flashing option.
* Use a better WantedBy (without a typo!)

can0_iobus_oneshot.service:
* Is a oneshot-service that can be used to setup the link
  parameters that can not be set using systemd-networkd.