### PR TITLE
4Do3Di3AiDriver: Remove bogus output

### DIFF
--- a/lxa_iobus/node_drivers.py
+++ b/lxa_iobus/node_drivers.py
@@ -84,7 +84,6 @@ class Iobus4Do3Di3AiDriver(NodeDriver):
             'OUT1': Pin(self.node, 'output', 0, 1),
             'OUT2': Pin(self.node, 'output', 0, 2),
             'OUT3': Pin(self.node, 'output', 0, 3),
-            'LED': Pin(self.node, 'output', 0, 4),
             'IN0': Pin(self.node, 'input', 0, 0),
             'IN1': Pin(self.node, 'input', 0, 1),
             'IN2': Pin(self.node, 'input', 0, 2),


### PR DESCRIPTION
The 4Do3Di3Ai does not support this Output in firmware anymore.
(Support has been dropped even before firmware 0.4.0.)

Klicking the button in the Web Interface does not do anything.
So we can remove this output entirely.
