### PR TITLE
driver/EthernetMux: Use product ID printed on the device

### DIFF
--- a/lxa_iobus/node_drivers.py
+++ b/lxa_iobus/node_drivers.py
@@ -142,7 +142,7 @@ class EthernetMuxDriver(NodeDriver):
     LSS_VENDOR = 0x507
     LSS_PRODUCT = 1
     LSS_REVISON = 4
-    NAME_PREFIX = 'Ethernet-Mux-00003.'
+    NAME_PREFIX = 'Ethernet-Mux-00012.'
 
     def _get_pins(self):
         return {


### PR DESCRIPTION
During development we used boards without housing. Those are internally
known as Ethernet-Mux 00003.x.
But devices are shipped in a housing. Thus the ID on the device changes
and is now 00012.x.

The devices still identify with the same LSS-information so this is just
a change in the representation.