### PR TITLE
Show LSS state and CAN TX error on status page

### DIFF
--- a/lxa_iobus/network.py
+++ b/lxa_iobus/network.py
@@ -284,7 +284,7 @@ class LxaNetwork:
         # TODO: check if we got the correct response
 
         # FIXME: sleep wird gebraucht weil RX nicht clean ist.
-        # wir krigen packete vom der letzten anfrage
+        # wir krigen Pakete vom der letzten anfrage
 
         response = await self.lss_request(
             gen_lss_fast_scan_message(lss_id, bit_checked, lss_sub, lss_next),
@@ -441,7 +441,7 @@ class LxaNetwork:
             )
 
             if not response:
-                logger.debug("fast_scan: Setting not ID not working")
+                logger.debug("fast_scan: No response to invalidate_node_IDs")
 
             response = await self.lss_request(
                 gen_lss_switch_mode_global_message(LSS_MODE.OPERATION),
@@ -485,7 +485,7 @@ class LxaNetwork:
                 )
 
                 if not response:
-                    logger.debug("fast_scan: Setting not ID not working")
+                    logger.debug("fast_scan: Setting node ID not working")
 
                 self.nodes[node_id] = LxaNode(
                     lxa_network=self,
@@ -503,7 +503,7 @@ class LxaNetwork:
                 )
 
                 if not response:
-                    logger.debug("fast_scan: Setting not ID not working")
+                    logger.debug("fast_scan: Setting node ID not working")
 
         except LxaShutdown:
             logger.debug('fast_scan: shutdown')

--- a/lxa_iobus/server/server.py
+++ b/lxa_iobus/server/server.py
@@ -156,6 +156,8 @@ class LXAIOBusServer:
             'started': str(self.started),
             'can_interface': self.network.interface,
             'can_interface_is_up': self.network.interface_is_up(),
+            'lss_state': self.network.lss_state.value,
+            'can_tx_error': self.network.tx_error,
         })
 
     async def index(self, request):

--- a/lxa_iobus/server/static/index.html
+++ b/lxa_iobus/server/static/index.html
@@ -21,8 +21,8 @@
       <div id="server-info">
         <div><strong>Hostname:</strong> <span id="server-info-hostname"></span></div>
         <div><strong>Server Started:</strong> <span id="server-info-server-started"></span></div>
-        <div><strong>Can Interface:</strong> <span id="server-info-can-interface"></span></div>
-        <div><strong>Can Interface State:</strong> <span id="server-info-can-interface-state"></span></div>
+        <div><strong>Can Interface:</strong> <span id="server-info-can-interface"></span> <span id="server-info-can-interface-state"> </span> <span id="server-info-can-tx-error"></div>
+        <div><strong>LSS State:</strong> <span id="server-info-lss-state"></span></div>
       </div>
 
       {{#if connected}}

--- a/lxa_iobus/server/static/main.js
+++ b/lxa_iobus/server/static/main.js
@@ -42,6 +42,8 @@ function update_info() {
         document.querySelector('#server-info-server-started').innerHTML = data['started'];
         document.querySelector('#server-info-can-interface').innerHTML = data['can_interface'];
         document.querySelector('#server-info-can-interface-state').innerHTML = data['can_interface_is_up'] ? 'UP' : 'DOWN';
+        document.querySelector('#server-info-can-tx-error').innerHTML = data['can_tx_error'] ? 'TX_ERROR!' : '';
+        document.querySelector('#server-info-lss-state').innerHTML = data['lss_state'];
     });
 };
 


### PR DESCRIPTION
This change propagates the network state into the ``/server-info/`` API
and displays this information on the status page.

Without this change the user did not get any feedback that a scan is in
progress. Especially with a new node (where the LSS address is not yet
cached) this takes a few seconds.
With this change a user gets feedback once a new node is discovered on
the bus and LSS tries to determine it's LSS address.

While implementing this I also plumbed the CAN TX error from the network
into the fronted.