### PR TITLE
server: add compatibilty with aiohttp 3.8

### DIFF
--- a/bin/lxa-iobus-server
+++ b/bin/lxa-iobus-server
@@ -160,7 +160,7 @@ try:
         kwargs["access_log"] = None
     run_app(app=app, host=args.host, port=args.port,
             handle_signals=False, print=lambda *args, **kwargs: None,
-            **kwargs)
+            loop=loop, **kwargs)
 
 except KeyboardInterrupt:
     server.shutdown()

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import lxa_iobus
 
 EXTRAS_REQUIRE = {
     'server': [
+        'aiohttp~=3.8',
         'aiohttp-json-rpc==0.13.3',
     ],
     'shell': [


### PR DESCRIPTION
The version string parsing was recommended by the maintainer of aiohttp
Andrew Svetlov

https://aio-libs.discourse.group/t/aiohttp-web-run-app-incompatibility-between-aiohttp-3-8-and-aiohttp-3-8/259/4

Signed-off-by: Florian Scherf <f.scherf@pengutronix.de>