### PR TITLE
Make lxa-iobus-server compatible with python 3.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 
 ### Eclipse ###
 .metadata
-bin/
 tmp/
 *.tmp
 *.bak

--- a/bin/lxa-iobus-server
+++ b/bin/lxa-iobus-server
@@ -103,7 +103,8 @@ log_level = {
 logging.basicConfig(level=log_level)
 
 # setup server
-loop = asyncio.get_event_loop()
+loop = asyncio.new_event_loop()
+asyncio.set_event_loop(loop)
 app = Application()
 
 # setup lxa network

--- a/lxa_iobus/node.py
+++ b/lxa_iobus/node.py
@@ -82,7 +82,6 @@ class LxaNode:
             await asyncio.wait_for(
                 async_fut,
                 timeout=timeout,
-                loop=self.lxa_network.loop,
             )
 
             return async_fut.result()


### PR DESCRIPTION
I've encountered two issues when running `lxa-iobus-server` with Python 3.10:

1. A warning that pops up once when starting the server:

     bin/lxa-iobus-server:106: DeprecationWarning: There is no current event loop
     loop = asyncio.get_event_loop()
     starting server on http://localhost:8080/

2. A warning that pops up very frequently:

    WARNING:LXAIOBusServer:Exception during get_info() for node <LxaNode(address=00000507.00000002.00000003.00000001, node_id=1, driver=<lxa_iobus.node_drivers.Iobus4Do3Di3AiDriver object at 0x7f1d51224cd0>)>: TypeError("wait_for() got an unexpected keyword argument 'loop'")

This MR should fix both of these warnings.

The change removing the `loop=` parameter from `wait_for` works for python versions `3.7` and higher.