### PR TITLE
Fix "LICENSE" typo in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [metadata]
 description = Linux Automation iobus
 long_description = file: README.rst
-license_file = LICENCE.txt
+license_file = LICENSE.txt


### PR DESCRIPTION
This typo results in the (kirkstone) bitbake python build magic not being able to build this package.