### PR TITLE
Add formatters and linters to the CI and fix the fallout

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = ./.git,./build,./venv,./env,./env-qa,./env-packaging,./node_modules,./lxa_iobus.egg-info,./lxa_iobus/server/static/lib

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -3,6 +3,16 @@ name: Quality Assurance
 on: [push, pull_request]
 
 jobs:
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: latest
+      - run: make qa-prettier
+
   ruff:
     name: Python Format and Lint
     runs-on: ubuntu-latest

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -3,6 +3,13 @@ name: Quality Assurance
 on: [push, pull_request]
 
 jobs:
+  codespell:
+    name: Codespell
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make qa-codespell
+
   prettier:
     name: Prettier
     runs-on: ubuntu-latest

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,11 @@
+name: Quality Assurance
+
+on: [push, pull_request]
+
+jobs:
+  ruff:
+    name: Python Format and Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: make qa-ruff

--- a/.gitignore
+++ b/.gitignore
@@ -280,3 +280,6 @@ tags
 lss-address-cache.json
 
 .idea
+/node_modules
+/package-lock.json
+/package.json

--- a/.gitignore
+++ b/.gitignore
@@ -231,6 +231,7 @@ ENV/
 env.bak/
 venv.bak/
 env-packaging/
+env-qa/
 
 # Spyder project settings
 .spyderproject
@@ -277,3 +278,5 @@ tags
 
 /firmware/
 lss-address-cache.json
+
+.idea

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["prettier-plugin-toml"]
+}

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ $(PYTHON_TESTING_ENV)/.created:
 	$(PYTHON) -m venv $(PYTHON_TESTING_ENV) && \
 	. $(PYTHON_TESTING_ENV)/bin/activate && \
 	python3 -m pip install pip --upgrade && \
-	python3 -m pip install ruff && \
+	python3 -m pip install ruff codespell && \
 	date > $(PYTHON_TESTING_ENV)/.created
 
 node_modules/.created:
@@ -60,9 +60,13 @@ node_modules/.created:
 	npm install -D prettier prettier-plugin-toml && \
 	date > node_modules/.created
 
-.PHONY: qa qa-ruff qa-ruff-fix qa-prettier
+.PHONY: qa qa-codespell qa-ruff qa-ruff-fix qa-prettier
 
-qa: qa-ruff qa-prettier
+qa: qa-codespell qa-ruff qa-prettier
+
+qa-codespell: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	codespell
 
 qa-ruff: $(PYTHON_TESTING_ENV)/.created
 	. $(PYTHON_TESTING_ENV)/bin/activate && \

--- a/Makefile
+++ b/Makefile
@@ -55,9 +55,14 @@ $(PYTHON_TESTING_ENV)/.created:
 	python3 -m pip install ruff && \
 	date > $(PYTHON_TESTING_ENV)/.created
 
-.PHONY: qa qa-ruff qa-ruff-fix
+node_modules/.created:
+	rm -rf node_modules && \
+	npm install -D prettier prettier-plugin-toml && \
+	date > node_modules/.created
 
-qa: qa-ruff
+.PHONY: qa qa-ruff qa-ruff-fix qa-prettier
+
+qa: qa-ruff qa-prettier
 
 qa-ruff: $(PYTHON_TESTING_ENV)/.created
 	. $(PYTHON_TESTING_ENV)/bin/activate && \
@@ -66,3 +71,9 @@ qa-ruff: $(PYTHON_TESTING_ENV)/.created
 qa-ruff-fix: $(PYTHON_TESTING_ENV)/.created
 	. $(PYTHON_TESTING_ENV)/bin/activate && \
 	ruff format && ruff check --fix
+
+qa-prettier: node_modules/.created
+	npx prettier --check pyproject.toml
+	npx prettier --check lxa_iobus/server/static/index.html
+	npx prettier --check lxa_iobus/server/static/main.js
+	npx prettier --check lxa_iobus/server/static/style.css

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 PYTHON=python3
 PYTHON_VENV=env
 PYTHON_PACKAGING_VENV=$(PYTHON_VENV)-packaging
+PYTHON_TESTING_ENV=$(PYTHON_VENV)-qa
 INTERFACE=can0
 LSS_ADDRESS_CACHE_FILE=lss-address-cache.json
 
@@ -16,6 +17,7 @@ env: $(PYTHON_VENV)/.created
 clean:
 	rm -rf $(PYTHON_VENV)
 	rm -rf $(PYTHON_PACKAGING_VENV)
+	rm -rf $(PYTHON_TESTING_ENV)
 
 server: env
 	. $(PYTHON_VENV)/bin/activate && \
@@ -43,3 +45,24 @@ sdist: packaging-env
 _release: sdist
 	. $(PYTHON_PACKAGING_VENV)/bin/activate && \
 	twine upload dist/*
+
+# testing #####################################################################
+$(PYTHON_TESTING_ENV)/.created:
+	rm -rf $(PYTHON_TESTING_ENV) && \
+	$(PYTHON) -m venv $(PYTHON_TESTING_ENV) && \
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	python3 -m pip install pip --upgrade && \
+	python3 -m pip install ruff && \
+	date > $(PYTHON_TESTING_ENV)/.created
+
+.PHONY: qa qa-ruff qa-ruff-fix
+
+qa: qa-ruff
+
+qa-ruff: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	ruff format --check --diff && ruff check
+
+qa-ruff-fix: $(PYTHON_TESTING_ENV)/.created
+	. $(PYTHON_TESTING_ENV)/bin/activate && \
+	ruff format && ruff check --fix

--- a/bin/lxa-iobus-lpc11xxcanisp-invoke
+++ b/bin/lxa-iobus-lpc11xxcanisp-invoke
@@ -1,9 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import contextlib
 import struct
 
 import canopen
+from canopen.sdo.exceptions import SdoCommunicationError
 
 
 class CanOpen:
@@ -31,10 +33,8 @@ def invoke_rom_loader():
     can = CanOpen()
     can.setup()
 
-    try:
+    with contextlib.suppress(SdoCommunicationError):
         can.invoke_isp()
-    except canopen.sdo.exceptions.SdoCommunicationError:
-        pass
 
 
 if __name__ == "__main__":

--- a/bin/lxa-iobus-lpc11xxcanisp-invoke
+++ b/bin/lxa-iobus-lpc11xxcanisp-invoke
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import canopen
 import struct
+
+import canopen
 
 
 class CanOpen:

--- a/bin/lxa-iobus-lpc11xxcanisp-invoke
+++ b/bin/lxa-iobus-lpc11xxcanisp-invoke
@@ -9,7 +9,7 @@ from canopen.sdo.exceptions import SdoCommunicationError
 
 
 class CanOpen:
-    """Minimal Setup to controll one ethmux"""
+    """Minimal Setup to control one ethmux"""
 
     def __init__(self, channel="can0", node_id=1):
         self.node_id = node_id

--- a/bin/lxa-iobus-lpc11xxcanisp-invoke
+++ b/bin/lxa-iobus-lpc11xxcanisp-invoke
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import canopen
-from time import sleep
 import struct
 
 

--- a/bin/lxa-iobus-lpc11xxcanisp-invoke
+++ b/bin/lxa-iobus-lpc11xxcanisp-invoke
@@ -5,12 +5,14 @@ import canopen
 from time import sleep
 import struct
 
+
 class CanOpen:
     """Minimal Setup to controll one ethmux"""
+
     def __init__(self, channel="can0", node_id=1):
         self.node_id = node_id
         self.network = canopen.Network()
-        self.network.connect(channel=channel, bustype='socketcan')
+        self.network.connect(channel=channel, bustype="socketcan")
         self.node = self.network.add_node(self.node_id)
 
     def setup(self):
@@ -22,7 +24,8 @@ class CanOpen:
 
     def invoke_isp(self):
         """set port state"""
-        self.node.sdo.download(0x2b07, 0, struct.pack("I", 0x12345678))
+        self.node.sdo.download(0x2B07, 0, struct.pack("I", 0x12345678))
+
 
 def invoke_rom_loader():
     can = CanOpen()
@@ -32,6 +35,7 @@ def invoke_rom_loader():
         can.invoke_isp()
     except canopen.sdo.exceptions.SdoCommunicationError:
         pass
+
 
 if __name__ == "__main__":
     invoke_rom_loader()

--- a/bin/lxa-iobus-lpc11xxcanisp-program
+++ b/bin/lxa-iobus-lpc11xxcanisp-program
@@ -67,7 +67,7 @@ class IspCompareError(Exception):
 
 class CanIsp:
     DATA_SIZES = {8: "B", 16: "H", 32: "I"}
-    ram_offset = 0x10000500  # Offset to savely usable RAM
+    ram_offset = 0x10000500  # Offset to safely usable RAM
 
     object_directory = {
         "Device Type": [0x1000, 0, 32],
@@ -177,7 +177,7 @@ class CanIsp:
 
     def unlock(self):
         """Unlocks write operations
-        Needs to be called befor writing to RAM or Flash"""
+        Needs to be called before writing to RAM or Flash"""
         self.send("Unlock Code", 23130)
 
     def write_to_ram(self, addr: int, data: bytes):
@@ -210,11 +210,11 @@ class CanIsp:
         self.send("Copy Length", length)
 
     def go(self, addr):
-        """Jumps to given addresse"""
+        """Jumps to given address"""
         self.send("Execution Address", addr)
         self.send("Program Control", 1)  # Trigger jump
 
-    def erase_flash_secotrs(self, start, stop):
+    def erase_flash_sectors(self, start, stop):
         """Clear given flash range"""
         if stop < start:
             raise ExceptionCanIsp("Sector range not ascending")
@@ -254,7 +254,7 @@ class CanIsp:
         obj = self.object_directory["Device Type"]
         return self._get(obj[0], obj[1], None)  # Get uint32 as bytearray
 
-    def compare(self, addr_1, addr_2, lenght):
+    def compare(self, addr_1, addr_2, length):
         """
         Takes two addresses and a length and compare the data.
         Raises IspCompareError if a mismatch is found.
@@ -262,14 +262,14 @@ class CanIsp:
         try:
             self.send("Compare Address 1", addr_1)
             self.send("Compare Address 2", addr_2)
-            self.send("Compare Length", lenght)
+            self.send("Compare Length", length)
         except IspSdoAbortedError as e:
             if e.str() == "COMPARE_ERROR":
                 offset = self.get("Compare mismatch")
                 raise IspCompareError(offset) from e
 
     def flash_image(self, start, data):
-        logging.info("Data to be writen: %d Byte", len(data))
+        logging.info("Data to be written: %d Byte", len(data))
 
         block_size = 4096
 
@@ -280,17 +280,17 @@ class CanIsp:
 
         # data must be multiple of block size
         # TODO add option for smaller block size
-        #      Supporte are: 256, 512, 1024, 4096.
+        #      Supported are: 256, 512, 1024, 4096.
         stuffing = len(data) % block_size
         if stuffing != 0:
             logging.info("Date buffer is extended by %d", stuffing)
             data += b"\xff" * (block_size - stuffing)
 
-        logging.info("Data to be writen %d Bytes", len(data))
+        logging.info("Data to be written %d Bytes", len(data))
         logging.info("Start sector %d", start_sector)
 
         sectors = len(data) // block_size
-        assert (len(data) % block_size) == 0, "Need to erease extra sector to fit date: %d" % len(data)
+        assert (len(data) % block_size) == 0, "Need to erase extra sector to fit date: %d" % len(data)
 
         logging.info("Sectors to write %d", sectors)
 
@@ -298,10 +298,10 @@ class CanIsp:
             raise Exception("Data to write does not fit into flash are of 32k")
 
         logging.info("Erasing blocks %d to %d", start_sector, start_sector + sectors - 1)
-        # TODO: Add check if we need to erease block use Blank check sectors
+        # TODO: Add check if we need to erase block use Blank check sectors
         self.unlock()  # Unlock writes
         self.prepare_flash_sectors(start_sector, start_sector + sectors - 1)
-        self.erase_flash_secotrs(start_sector, start_sector + sectors - 1)
+        self.erase_flash_sectors(start_sector, start_sector + sectors - 1)
 
         blocks = sectors
 
@@ -323,13 +323,13 @@ class CanIsp:
 
 def fix_checksum(data):
     """
-    This generate the checksum in the vectro table.
-    This is needed for the LPC11CXX und probebly all Cortex-M0.
-    and is normaly done somewhere in the swd programming chain.
+    This generate the checksum in the vector table.
+    This is needed for the LPC11CXX und probably all Cortex-M0.
+    and is normally done somewhere in the swd programming chain.
     For more info see: UM10398 26.3.3 Criterion for Valid User Code.
     """
 
-    vector_table = data[0 : 4 * 7]  # First 7 entrys
+    vector_table = data[0 : 4 * 7]  # First 7 entries
     vector_table = struct.unpack("iiiiiii", vector_table)
 
     checksum = 0 - (sum(vector_table))

--- a/bin/lxa-iobus-lpc11xxcanisp-program
+++ b/bin/lxa-iobus-lpc11xxcanisp-program
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import canopen
-import struct
-import time
 import argparse
 import logging
 import os
+import struct
+import time
+
+import canopen
 
 from lxa_iobus.lpc11xxcanisp import loader
 

--- a/bin/lxa-iobus-lpc11xxcanisp-program
+++ b/bin/lxa-iobus-lpc11xxcanisp-program
@@ -349,7 +349,9 @@ def _isp_info(isp):
 def _isp_write(isp, filename, section):
     assert section in ["config", "flash"]
 
-    data = open(filename, "rb").read()
+    with open(filename, "rb") as fd:
+        data = fd.read()
+
     if section == "flash":
         data = fix_checksum(data)
 
@@ -392,11 +394,14 @@ def _isp_read(isp, filename, section):
 
     stop_t = time.time()
     print("Read", length, "in", stop_t - start_t, ":", length / (stop_t - start_t), "Bytes/sec")
-    open(filename, "wb").write(data)
+
+    with open(filename, "wb") as fd:
+        fd.write(data)
 
 
 def _isp_exec(isp, filename):
-    data = open(filename, "rb").read()
+    with open(filename, "rb") as fd:
+        data = fd.read()
 
     isp.unlock()
     isp.write_to_ram(0x10000500, data)

--- a/bin/lxa-iobus-lpc11xxcanisp-program
+++ b/bin/lxa-iobus-lpc11xxcanisp-program
@@ -3,7 +3,6 @@
 
 import canopen
 import struct
-import sys
 import time
 import argparse
 import logging
@@ -51,7 +50,7 @@ class IspSdoAbortedError(Exception):
     def __str__(self):
         text = "Code 0x{:08X}".format(self.code)
         reason = self.str()
-        if not reason is None:
+        if reason is not None:
             text += ", " + reason
         return text
 
@@ -99,50 +98,28 @@ class CanIsp:
 
     part_ids = {
         0x041E502B: "LPC1111FHN33/101",
-        0x2516D02B: "LPC1111FHN33/101",
         0x2516D02B: "LPC1111FHN33/102",
         0x0416502B: "LPC1111FHN33/201",
-        0x2516902B: "LPC1111FHN33/201",
         0x2516902B: "LPC1111FHN33/202",
         0x00010013: "LPC1111FHN33/103",
         0x00010012: "LPC1111FHN33/203",
         0x042D502B: "LPC1112FHN33/101",
-        0x2524D02B: "LPC1112FHN33/101",
         0x2524D02B: "LPC1112FHN33/102",
         0x0425502B: "LPC1112FHN33/201",
-        0x2524902B: "LPC1112FHN33/201",
-        0x2524902B: "LPC1112FHN33/202",
         0x2524902B: "LPC1112FHI33/202",
         0x00020023: "LPC1112FHN33/103",
-        0x00020022: "LPC1112FHN33/203",
         0x00020022: "LPC1112FHI33/203",
         0x0434502B: "LPC1113FHN33/201",
-        0x2532902B: "LPC1113FHN33/201",
         0x2532902B: "LPC1113FHN33/202",
-        0x0434102B: "LPC1113FHN33/301",
-        0x2532102B: "LPC1113FHN33/301",
-        0x2532102B: "LPC1113FHN33/302",
         0x0434102B: "LPC1113FBD48/301",
-        0x2532102B: "LPC1113FBD48/301",
         0x2532102B: "LPC1113FBD48/302",
-        0x00030030: "LPC1113FBD48/303",
         0x00030032: "LPC1113FHN33/203",
         0x00030030: "LPC1113FHN33/303",
         0x0444502B: "LPC1114FHN33/201",
-        0x2540902B: "LPC1114FHN33/201",
         0x2540902B: "LPC1114FHN33/202",
-        0x0444102B: "LPC1114FHN33/301",
-        0x2540102B: "LPC1114FHN33/301",
-        0x2540102B: "LPC1114FHN33/302",
-        0x2540102B: "LPC1114FHI33/302",
         0x0444102B: "LPC1114FBD48/301",
-        0x2540102B: "LPC1114FBD48/301",
-        0x2540102B: "LPC1114FBD48/302",
-        0x00040040: "LPC1114FBD48/303",
         0x00040042: "LPC1114FHN33/203",
-        0x00040040: "LPC1114FHN33/303",
         0x00040060: "LPC1114FBD48/323",
-        0x00040070: "LPC1114FBD48/333",
         0x00040070: "LPC1114FHN33/333",
         0x00040040: "LPC1114FHI33/303",
         0x2540102B: "LPC11D14FBD100/302",
@@ -179,7 +156,7 @@ class CanIsp:
             self.node.sdo.download(index, subindex, self.pack(num, size=size))
         except canopen.sdo.exceptions.SdoAbortedError as e:
             if IspSdoAbortedError.is_known(e.code):
-                raise IspSdoAbortedError(e.code)
+                raise IspSdoAbortedError(e.code) from e
             raise e
 
     def send(self, name, value):
@@ -191,7 +168,7 @@ class CanIsp:
             return self.unpack(self.node.sdo.upload(index, subindex), size)
         except canopen.sdo.exceptions.SdoAbortedError as e:
             if IspSdoAbortedError.is_known(e.code):
-                raise IspSdoAbortedError(e.code)
+                raise IspSdoAbortedError(e.code) from e
             raise e
 
     def get(self, name):
@@ -288,7 +265,7 @@ class CanIsp:
         except IspSdoAbortedError as e:
             if e.str() == "COMPARE_ERROR":
                 offset = self.get("Compare mismatch")
-                raise IspCompareError(offset)
+                raise IspCompareError(offset) from e
 
     def flash_image(self, start, data):
         logging.info("Data to be writen: %d Byte", len(data))

--- a/bin/lxa-iobus-lpc11xxcanisp-program
+++ b/bin/lxa-iobus-lpc11xxcanisp-program
@@ -17,25 +17,26 @@ basepath = os.path.dirname(os.path.dirname(loader.__file__))
 class ExceptionCanIsp(Exception):
     pass
 
+
 class IspSdoAbortedError(Exception):
     abort_codes = {
-            0x0F00000D: "ADDR_ERROR",
-            0x0F00000E: "ADDR_NOT_MAPPED",
-            0x0F00000F: "CMD_LOCKED",
-            0x0F000013: "CODE_READ_PROTECTION_ENABLED",
-            0x0F00000A: "COMPARE_ERROR",
-            0x0F000006: "COUNT_ERROR",
-            0x0F000003: "DST_ADDR_ERROR",
-            0x0F000005: "DST_ADDR_NOT_MAPPED",
-            0x0F000010: "INVALID_CODE",
-            0x0F000001: "INVALID_COMMAND",
-            0x0F000007: "INVALID_SECTOR",
-            0x0F00000C: "PARAM_ERROR",
-            0x0F000008: "SECTOR_NOT_BLANK",
-            0x0F000009: "SECTOR_NOT_PREPARED_FOR_WRITE_OPERATION",
-            0x0F000002: "SRC_ADDR_ERROR",
-            0x0F000004: "SRC_ADDR_NOT_MAPPED"
-            }
+        0x0F00000D: "ADDR_ERROR",
+        0x0F00000E: "ADDR_NOT_MAPPED",
+        0x0F00000F: "CMD_LOCKED",
+        0x0F000013: "CODE_READ_PROTECTION_ENABLED",
+        0x0F00000A: "COMPARE_ERROR",
+        0x0F000006: "COUNT_ERROR",
+        0x0F000003: "DST_ADDR_ERROR",
+        0x0F000005: "DST_ADDR_NOT_MAPPED",
+        0x0F000010: "INVALID_CODE",
+        0x0F000001: "INVALID_COMMAND",
+        0x0F000007: "INVALID_SECTOR",
+        0x0F00000C: "PARAM_ERROR",
+        0x0F000008: "SECTOR_NOT_BLANK",
+        0x0F000009: "SECTOR_NOT_PREPARED_FOR_WRITE_OPERATION",
+        0x0F000002: "SRC_ADDR_ERROR",
+        0x0F000004: "SRC_ADDR_NOT_MAPPED",
+    }
 
     def __init__(self, code):
         self.code = code
@@ -54,6 +55,7 @@ class IspSdoAbortedError(Exception):
             text += ", " + reason
         return text
 
+
 class IspCompareError(Exception):
     def __init__(self, offset):
         self.offset = offset
@@ -65,103 +67,97 @@ class IspCompareError(Exception):
 
 class CanIsp:
     DATA_SIZES = {8: "B", 16: "H", 32: "I"}
-    ram_offset = 0x10000500 # Offset to savely usable RAM
+    ram_offset = 0x10000500  # Offset to savely usable RAM
 
     object_directory = {
-            "Device Type": [ 0x1000, 0, 32 ],
-            "Vendor ID": [ 0x1018, 1, 32 ], # Not used: should be 0
-            "Part Identification Number": [ 0x1018, 2, 32 ],
-            "Boot Code Version Number": [ 0x1018, 3, 32 ],
-            "Program Area": [ 0x1F50, 1, None ], #DOMAIN
-            "Program Control": [ 0x1F51, 1, 8 ],
-            "Unlock Code": [ 0x5000, 0, 16 ],
-
-            "Memory Read Address": [ 0x5010, 0, 32 ],
-            "Memory Read Length": [ 0x5011, 0, 32 ],
-
-            "RAM Write Address": [ 0x5015, 0, 32 ],
-
-            "Prepare Sectors for Write": [ 0x5020, 0, 16 ],
-            "Erase Sectors": [ 0x5030, 0, 16 ],
-
-            "Check sectors": [ 0x5040, 1, 16 ],
-
-            "Copy Flash Address": [ 0x5050, 1, 32 ],
-            "Copy RAM Address": [ 0x5050, 2, 32 ],
-            "Copy Length": [ 0x5050, 3, 16 ],
-
-            "Compare Address 1": [ 0x5060, 1, 32 ],
-            "Compare Address 2": [ 0x5060, 2, 32 ],
-            "Compare Length": [ 0x5060, 3, 16 ],
-            "Compare mismatch": [ 0x5060, 4, 32 ],
-            "Execution Address": [ 0x5070, 1, 32 ],
-            "Serial Number 1": [ 0x5100, 1, 32 ],
-            "Serial Number 2": [ 0x5100, 2, 32 ],
-            "Serial Number 3": [ 0x5100, 3, 32 ],
-            "Serial Number 4": [ 0x5100, 4, 32 ]
-            }
+        "Device Type": [0x1000, 0, 32],
+        "Vendor ID": [0x1018, 1, 32],  # Not used: should be 0
+        "Part Identification Number": [0x1018, 2, 32],
+        "Boot Code Version Number": [0x1018, 3, 32],
+        "Program Area": [0x1F50, 1, None],  # DOMAIN
+        "Program Control": [0x1F51, 1, 8],
+        "Unlock Code": [0x5000, 0, 16],
+        "Memory Read Address": [0x5010, 0, 32],
+        "Memory Read Length": [0x5011, 0, 32],
+        "RAM Write Address": [0x5015, 0, 32],
+        "Prepare Sectors for Write": [0x5020, 0, 16],
+        "Erase Sectors": [0x5030, 0, 16],
+        "Check sectors": [0x5040, 1, 16],
+        "Copy Flash Address": [0x5050, 1, 32],
+        "Copy RAM Address": [0x5050, 2, 32],
+        "Copy Length": [0x5050, 3, 16],
+        "Compare Address 1": [0x5060, 1, 32],
+        "Compare Address 2": [0x5060, 2, 32],
+        "Compare Length": [0x5060, 3, 16],
+        "Compare mismatch": [0x5060, 4, 32],
+        "Execution Address": [0x5070, 1, 32],
+        "Serial Number 1": [0x5100, 1, 32],
+        "Serial Number 2": [0x5100, 2, 32],
+        "Serial Number 3": [0x5100, 3, 32],
+        "Serial Number 4": [0x5100, 4, 32],
+    }
 
     part_ids = {
-            0x041E502B: "LPC1111FHN33/101",
-            0x2516D02B: "LPC1111FHN33/101",
-            0x2516D02B: "LPC1111FHN33/102",
-            0x0416502B: "LPC1111FHN33/201",
-            0x2516902B: "LPC1111FHN33/201",
-            0x2516902B: "LPC1111FHN33/202",
-            0x00010013: "LPC1111FHN33/103",
-            0x00010012: "LPC1111FHN33/203",
-            0x042D502B: "LPC1112FHN33/101",
-            0x2524D02B: "LPC1112FHN33/101",
-            0x2524D02B: "LPC1112FHN33/102",
-            0x0425502B: "LPC1112FHN33/201",
-            0x2524902B: "LPC1112FHN33/201",
-            0x2524902B: "LPC1112FHN33/202",
-            0x2524902B: "LPC1112FHI33/202",
-            0x00020023: "LPC1112FHN33/103",
-            0x00020022: "LPC1112FHN33/203",
-            0x00020022: "LPC1112FHI33/203",
-            0x0434502B: "LPC1113FHN33/201",
-            0x2532902B: "LPC1113FHN33/201",
-            0x2532902B: "LPC1113FHN33/202",
-            0x0434102B: "LPC1113FHN33/301",
-            0x2532102B: "LPC1113FHN33/301",
-            0x2532102B: "LPC1113FHN33/302",
-            0x0434102B: "LPC1113FBD48/301",
-            0x2532102B: "LPC1113FBD48/301",
-            0x2532102B: "LPC1113FBD48/302",
-            0x00030030: "LPC1113FBD48/303",
-            0x00030032: "LPC1113FHN33/203",
-            0x00030030: "LPC1113FHN33/303",
-            0x0444502B: "LPC1114FHN33/201",
-            0x2540902B: "LPC1114FHN33/201",
-            0x2540902B: "LPC1114FHN33/202",
-            0x0444102B: "LPC1114FHN33/301",
-            0x2540102B: "LPC1114FHN33/301",
-            0x2540102B: "LPC1114FHN33/302",
-            0x2540102B: "LPC1114FHI33/302",
-            0x0444102B: "LPC1114FBD48/301",
-            0x2540102B: "LPC1114FBD48/301",
-            0x2540102B: "LPC1114FBD48/302",
-            0x00040040: "LPC1114FBD48/303",
-            0x00040042: "LPC1114FHN33/203",
-            0x00040040: "LPC1114FHN33/303",
-            0x00040060: "LPC1114FBD48/323",
-            0x00040070: "LPC1114FBD48/333",
-            0x00040070: "LPC1114FHN33/333",
-            0x00040040: "LPC1114FHI33/303",
-            0x2540102B: "LPC11D14FBD100/302",
-            0x00050080: "LPC1115FBD48/303",
-            0x1421102B: "LPC11C12FBD48/301",
-            0x1440102B: "LPC11C14FBD48/301",
-            0x1431102B: "LPC11C22FBD48/301",
-            0x1430102B: "LPC11C24FBD48/301"
-            }
+        0x041E502B: "LPC1111FHN33/101",
+        0x2516D02B: "LPC1111FHN33/101",
+        0x2516D02B: "LPC1111FHN33/102",
+        0x0416502B: "LPC1111FHN33/201",
+        0x2516902B: "LPC1111FHN33/201",
+        0x2516902B: "LPC1111FHN33/202",
+        0x00010013: "LPC1111FHN33/103",
+        0x00010012: "LPC1111FHN33/203",
+        0x042D502B: "LPC1112FHN33/101",
+        0x2524D02B: "LPC1112FHN33/101",
+        0x2524D02B: "LPC1112FHN33/102",
+        0x0425502B: "LPC1112FHN33/201",
+        0x2524902B: "LPC1112FHN33/201",
+        0x2524902B: "LPC1112FHN33/202",
+        0x2524902B: "LPC1112FHI33/202",
+        0x00020023: "LPC1112FHN33/103",
+        0x00020022: "LPC1112FHN33/203",
+        0x00020022: "LPC1112FHI33/203",
+        0x0434502B: "LPC1113FHN33/201",
+        0x2532902B: "LPC1113FHN33/201",
+        0x2532902B: "LPC1113FHN33/202",
+        0x0434102B: "LPC1113FHN33/301",
+        0x2532102B: "LPC1113FHN33/301",
+        0x2532102B: "LPC1113FHN33/302",
+        0x0434102B: "LPC1113FBD48/301",
+        0x2532102B: "LPC1113FBD48/301",
+        0x2532102B: "LPC1113FBD48/302",
+        0x00030030: "LPC1113FBD48/303",
+        0x00030032: "LPC1113FHN33/203",
+        0x00030030: "LPC1113FHN33/303",
+        0x0444502B: "LPC1114FHN33/201",
+        0x2540902B: "LPC1114FHN33/201",
+        0x2540902B: "LPC1114FHN33/202",
+        0x0444102B: "LPC1114FHN33/301",
+        0x2540102B: "LPC1114FHN33/301",
+        0x2540102B: "LPC1114FHN33/302",
+        0x2540102B: "LPC1114FHI33/302",
+        0x0444102B: "LPC1114FBD48/301",
+        0x2540102B: "LPC1114FBD48/301",
+        0x2540102B: "LPC1114FBD48/302",
+        0x00040040: "LPC1114FBD48/303",
+        0x00040042: "LPC1114FHN33/203",
+        0x00040040: "LPC1114FHN33/303",
+        0x00040060: "LPC1114FBD48/323",
+        0x00040070: "LPC1114FBD48/333",
+        0x00040070: "LPC1114FHN33/333",
+        0x00040040: "LPC1114FHI33/303",
+        0x2540102B: "LPC11D14FBD100/302",
+        0x00050080: "LPC1115FBD48/303",
+        0x1421102B: "LPC11C12FBD48/301",
+        0x1440102B: "LPC11C14FBD48/301",
+        0x1431102B: "LPC11C22FBD48/301",
+        0x1430102B: "LPC11C24FBD48/301",
+    }
 
     def __init__(self, node):
         self.node = node
 
     @staticmethod
-    def unpack(data: bytes, size:int = None):
+    def unpack(data: bytes, size: int = None):
         """converts binary data to in depending on number of bits"""
         if size is None:
             return data
@@ -204,7 +200,7 @@ class CanIsp:
     def unlock(self):
         """Unlocks write operations
         Needs to be called befor writing to RAM or Flash"""
-        self.send("Unlock Code",  23130)
+        self.send("Unlock Code", 23130)
 
     def write_to_ram(self, addr: int, data: bytes):
         """Writes data to RAM at addr"""
@@ -225,20 +221,20 @@ class CanIsp:
         if start > 8 or stop > 8:
             raise ExceptionCanIsp("Sector out of range")
 
-        self.send("Prepare Sectors for Write", ( (start&0xff) | ((stop&0xff)<<8) ) )
+        self.send("Prepare Sectors for Write", ((start & 0xFF) | ((stop & 0xFF) << 8)))
 
     def copy_ram_to_flash(self, ram_addr, flash_addr, length):
         """Copies RAM range to flash"""
         # TODO: Check for alignment
         # TODO: Check FLASH size
-        self.send("Copy Flash Address", flash_addr )
-        self.send("Copy RAM Address", ram_addr )
-        self.send("Copy Length", length )
+        self.send("Copy Flash Address", flash_addr)
+        self.send("Copy RAM Address", ram_addr)
+        self.send("Copy Length", length)
 
     def go(self, addr):
         """Jumps to given addresse"""
         self.send("Execution Address", addr)
-        self.send("Program Control", 1) # Trigger jump
+        self.send("Program Control", 1)  # Trigger jump
 
     def erase_flash_secotrs(self, start, stop):
         """Clear given flash range"""
@@ -248,8 +244,7 @@ class CanIsp:
         if start > 8 or stop > 8:
             raise ExceptionCanIsp("Sector out of range")
 
-        self.send("Erase Sectors", ( (start&0xff) | ((stop&0xff)<<8) ) )
-
+        self.send("Erase Sectors", ((start & 0xFF) | ((stop & 0xFF) << 8)))
 
     def read_memory(self, addr: int, length: int) -> bytes:
         """Dumps part of the MCUs memory"""
@@ -269,7 +264,7 @@ class CanIsp:
 
     def read_serial_number(self) -> [int]:
         """returns MCU serial number as an array with 4 32-bit unsigned integers"""
-        uid = [0,0,0,0]
+        uid = [0, 0, 0, 0]
         uid[0] = self.get("Serial Number 1")
         uid[1] = self.get("Serial Number 2")
         uid[2] = self.get("Serial Number 3")
@@ -279,7 +274,7 @@ class CanIsp:
     def read_device_type(self) -> bytes:
         """The device type should always be 'LPC1'"""
         obj = self.object_directory["Device Type"]
-        return self._get(obj[0], obj[1], None) # Get uint32 as bytearray
+        return self._get(obj[0], obj[1], None)  # Get uint32 as bytearray
 
     def compare(self, addr_1, addr_2, lenght):
         """
@@ -287,14 +282,13 @@ class CanIsp:
         Raises IspCompareError if a mismatch is found.
         """
         try:
-            self.send("Compare Address 1", addr_1 )
-            self.send("Compare Address 2", addr_2 )
-            self.send("Compare Length", lenght )
+            self.send("Compare Address 1", addr_1)
+            self.send("Compare Address 2", addr_2)
+            self.send("Compare Length", lenght)
         except IspSdoAbortedError as e:
             if e.str() == "COMPARE_ERROR":
                 offset = self.get("Compare mismatch")
                 raise IspCompareError(offset)
-
 
     def flash_image(self, start, data):
         logging.info("Data to be writen: %d Byte", len(data))
@@ -304,49 +298,49 @@ class CanIsp:
         if (start % block_size) != 0:
             raise Exception("Start must be a multiple of 4096!")
 
-        start_sector = start//block_size
+        start_sector = start // block_size
 
-        #data must be multiple of block size
+        # data must be multiple of block size
         # TODO add option for smaller block size
         #      Supporte are: 256, 512, 1024, 4096.
-        stuffing = len(data)%block_size
+        stuffing = len(data) % block_size
         if stuffing != 0:
             logging.info("Date buffer is extended by %d", stuffing)
-            data += b"\xff"*(block_size-stuffing)
+            data += b"\xff" * (block_size - stuffing)
 
         logging.info("Data to be writen %d Bytes", len(data))
-        logging.info("Start sector %d" , start_sector)
+        logging.info("Start sector %d", start_sector)
 
-        sectors = len(data)//block_size
-        assert (len(data)%block_size) == 0, "Need to erease extra sector to fit date: %d" % len(data)
+        sectors = len(data) // block_size
+        assert (len(data) % block_size) == 0, "Need to erease extra sector to fit date: %d" % len(data)
 
         logging.info("Sectors to write %d", sectors)
-
 
         if start_sector + sectors > 8:
             raise Exception("Data to write does not fit into flash are of 32k")
 
-        logging.info("Erasing blocks %d to %d", start_sector, start_sector+sectors-1)
+        logging.info("Erasing blocks %d to %d", start_sector, start_sector + sectors - 1)
         # TODO: Add check if we need to erease block use Blank check sectors
-        self.unlock() # Unlock writes
-        self.prepare_flash_sectors(start_sector, start_sector+sectors-1)
-        self.erase_flash_secotrs(start_sector, start_sector+sectors-1)
+        self.unlock()  # Unlock writes
+        self.prepare_flash_sectors(start_sector, start_sector + sectors - 1)
+        self.erase_flash_secotrs(start_sector, start_sector + sectors - 1)
 
         blocks = sectors
 
-
-        for block_num in range(start_sector, start_sector+blocks):
+        for block_num in range(start_sector, start_sector + blocks):
             logging.info("Send block %d", block_num)
 
-            start_offset = block_size*(block_num-start_sector)
+            start_offset = block_size * (block_num - start_sector)
 
-            block = data[start_offset: start_offset + block_size]
+            block = data[start_offset : start_offset + block_size]
             logging.info("Block length %d", len(block))
-            self.write_to_ram(self.ram_offset, block) # Transfer data block to the RAM of the MCU
+            self.write_to_ram(self.ram_offset, block)  # Transfer data block to the RAM of the MCU
 
             logging.info("Copy to Flash")
             self.prepare_flash_sectors(block_num, block_num)
-            self.copy_ram_to_flash(self.ram_offset, block_size*block_num, block_size) # Copy block from MCU RAM to MCU Flash
+            self.copy_ram_to_flash(
+                self.ram_offset, block_size * block_num, block_size
+            )  # Copy block from MCU RAM to MCU Flash
 
 
 def fix_checksum(data):
@@ -357,35 +351,37 @@ def fix_checksum(data):
     For more info see: UM10398 26.3.3 Criterion for Valid User Code.
     """
 
-    vector_table = data[0:4*7] # First 7 entrys
+    vector_table = data[0 : 4 * 7]  # First 7 entrys
     vector_table = struct.unpack("iiiiiii", vector_table)
 
-    checksum = 0-(sum(vector_table))
+    checksum = 0 - (sum(vector_table))
     checksum = struct.pack("i", checksum)
 
-    data = data[0:4*7] + checksum + data[4*8:]
+    data = data[0 : 4 * 7] + checksum + data[4 * 8 :]
     return data
+
 
 def _isp_info(isp):
     print("device_type:", isp.read_device_type())
     print("partID: 0x{:08X} {}".format(*isp.read_partID()))
     print("serial_number: {:08X} {:08X} {:08X} {:08X}".format(*isp.read_serial_number()))
-    print("bootloader_version: {:08X}".format( isp.read_bootloader_version()))
+    print("bootloader_version: {:08X}".format(isp.read_bootloader_version()))
+
 
 def _isp_write(isp, filename, section):
-    assert(section in ["config", "flash"])
+    assert section in ["config", "flash"]
 
     data = open(filename, "rb").read()
     if section == "flash":
         data = fix_checksum(data)
 
     if section == "flash":
-        length = 28*1024
-        start  = 0
+        length = 28 * 1024
+        start = 0
     else:
         # config
-        length= 4*1024
-        start = 28*1024
+        length = 4 * 1024
+        start = 28 * 1024
 
     if len(data) > length:
         print("Supplied Image is too long for section. Allowed {} bytes, is {} bytes".format(length, len(data)))
@@ -397,18 +393,19 @@ def _isp_write(isp, filename, section):
     isp.flash_image(start, data)
 
     stop_t = time.time()
-    print("Write", len(data), "in", stop_t-start_t, ":", len(data)/(stop_t-start_t),"Bytes/sec")
+    print("Write", len(data), "in", stop_t - start_t, ":", len(data) / (stop_t - start_t), "Bytes/sec")
+
 
 def _isp_read(isp, filename, section):
-    assert(section in ["config", "flash"])
+    assert section in ["config", "flash"]
 
     if section == "flash":
-        length = 28*1024
-        start  = 0
+        length = 28 * 1024
+        start = 0
     else:
         # config
-        length= 4*1024
-        start = 28*1024
+        length = 4 * 1024
+        start = 28 * 1024
 
     print("Reading section {}".format(section))
     start_t = time.time()
@@ -416,8 +413,9 @@ def _isp_read(isp, filename, section):
     data = isp.read_memory(start, length)
 
     stop_t = time.time()
-    print("Read", length, "in", stop_t-start_t, ":", length/(stop_t-start_t),"Bytes/sec")
+    print("Read", length, "in", stop_t - start_t, ":", length / (stop_t - start_t), "Bytes/sec")
     open(filename, "wb").write(data)
+
 
 def _isp_exec(isp, filename):
     data = open(filename, "rb").read()
@@ -426,23 +424,26 @@ def _isp_exec(isp, filename):
     isp.write_to_ram(0x10000500, data)
     isp.go(0x10000500)
 
+
 def isp_readflash(filename):
     _isp_read(isp, filename, "flash")
+
 
 def isp_readconfig(filename):
     _isp_read(isp, filename, "config")
 
+
 def isp_writeflash(filename):
     _isp_write(isp, filename, "flash")
+
 
 def isp_writeconfig(filename):
     _isp_write(isp, filename, "config")
 
+
 def isp_reset():
-    _isp_exec(
-        isp,
-        os.path.join(basepath,"loader/reset.bin")
-        )
+    _isp_exec(isp, os.path.join(basepath, "loader/reset.bin"))
+
 
 def main():
     parser = argparse.ArgumentParser("can_isp.py")
@@ -468,8 +469,7 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.function in ["readflash", "writeflash", "readconfig", "writeconfig"] \
-       and args.file is None:
+    if args.function in ["readflash", "writeflash", "readconfig", "writeconfig"] and args.file is None:
         parser.error("file is required for this function")
         exit(1)
 
@@ -477,7 +477,6 @@ def main():
         logging.basicConfig(level=logging.INFO)
     else:
         logging.basicConfig(level=logging.WARN)
-
 
     if not args.s:
         _isp_info(isp)
@@ -493,8 +492,9 @@ def main():
     elif args.function == "reset":
         isp_reset()
 
+
 network = canopen.Network()
-network.connect(channel='can0', bustype='socketcan')
+network.connect(channel="can0", bustype="socketcan")
 node = network.add_node(125)
 isp = CanIsp(node)
 

--- a/bin/lxa-iobus-lpc11xxcanisp-program
+++ b/bin/lxa-iobus-lpc11xxcanisp-program
@@ -252,7 +252,7 @@ class CanIsp:
         self.send("Memory Read Length", length)
         return self.get("Program Area")
 
-    def read_partID(self) -> int:
+    def read_part_id(self) -> int:
         """Returns a tuple with the part id and the part name if known otherwise None"""
         part_id = self.get("Part Identification Number")
         part_name = self.part_ids.get(part_id, None)
@@ -363,7 +363,7 @@ def fix_checksum(data):
 
 def _isp_info(isp):
     print("device_type:", isp.read_device_type())
-    print("partID: 0x{:08X} {}".format(*isp.read_partID()))
+    print("partID: 0x{:08X} {}".format(*isp.read_part_id()))
     print("serial_number: {:08X} {:08X} {:08X} {:08X}".format(*isp.read_serial_number()))
     print("bootloader_version: {:08X}".format(isp.read_bootloader_version()))
 

--- a/bin/lxa-iobus-server
+++ b/bin/lxa-iobus-server
@@ -1,20 +1,20 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from argparse import ArgumentParser
-import traceback
-import threading
 import asyncio
-import logging
-import signal
 import errno
-import sys
+import logging
 import os
+import signal
+import sys
+import threading
+import traceback
+from argparse import ArgumentParser
 
 from aiohttp.web import Application, run_app
 
-from lxa_iobus.server.server import LXAIOBusServer
 from lxa_iobus.network import LxaNetwork
+from lxa_iobus.server.server import LXAIOBusServer
 
 
 def trace_handler(num, frame):
@@ -142,8 +142,8 @@ loop.create_task(server.flush_state_periodicly())
 if args.shell:
 
     def _start_shell():
-        from traitlets.config import Config
         import IPython
+        from traitlets.config import Config
 
         config = Config()
 

--- a/bin/lxa-iobus-server
+++ b/bin/lxa-iobus-server
@@ -137,7 +137,7 @@ except OSError as e:
     if e.errno == errno.ENODEV:  # can interface not available
         exit("interface {} not available".format(args.interface))
 
-loop.create_task(server.flush_state_periodicly())
+loop.create_task(server.flush_state_periodically())
 
 if args.shell:
 

--- a/bin/lxa-iobus-server
+++ b/bin/lxa-iobus-server
@@ -45,59 +45,58 @@ signal.signal(signal.SIGINT, exit_handler)
 # parse command line arguments
 parser = ArgumentParser()
 
-parser.add_argument('interface')
+parser.add_argument("interface")
 parser.add_argument(
-    '--port',
+    "--port",
     type=int,
     default=8080,
-    help='Port to serve on. Defaults to 8080',
+    help="Port to serve on. Defaults to 8080",
 )
 parser.add_argument(
-    '--host',
+    "--host",
     type=str,
-    default='localhost',
-    help='Host to bind to. Defaults to \'localhost\'',
+    default="localhost",
+    help="Host to bind to. Defaults to 'localhost'",
 )
 parser.add_argument(
-    '--shell',
-    action='store_true',
-    help='Embeds an ipython shell for easy debugging',
+    "--shell",
+    action="store_true",
+    help="Embeds an ipython shell for easy debugging",
 )
 parser.add_argument(
-    '--firmware-directory',
+    "--firmware-directory",
     type=str,
-    default='firmware',
-    help='Directory where uploaded firmware is stored. '
-    'Only used when --allow-custom-firmware is set.'
+    default="firmware",
+    help="Directory where uploaded firmware is stored. " "Only used when --allow-custom-firmware is set.",
 )
 parser.add_argument(
-    '--allow-custom-firmware',
-    action='store_true',
-    help='Allows to upload and flash own (arbitrary) firmware '
-    'into the program section of the nodes.'
+    "--allow-custom-firmware",
+    action="store_true",
+    help="Allows to upload and flash own (arbitrary) firmware " "into the program section of the nodes.",
 )
 parser.add_argument(
-    '--lss-address-cache-file',
+    "--lss-address-cache-file",
     type=str,
-    default='',
-    help='LSS addresses cache as json. Reduces startup time for known nodes.',
+    default="",
+    help="LSS addresses cache as json. Reduces startup time for known nodes.",
 )
 
 parser.add_argument(
-    '-l', '--log-level',
-    choices=['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'],
-    default='WARN',
+    "-l",
+    "--log-level",
+    choices=["DEBUG", "INFO", "WARN", "ERROR", "FATAL"],
+    default="WARN",
 )
 
 args = parser.parse_args()
 
 # setup logging
 log_level = {
-    'DEBUG': logging.DEBUG,
-    'INFO': logging.INFO,
-    'WARN': logging.WARN,
-    'ERROR': logging.ERROR,
-    'FATAL': logging.FATAL,
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARN": logging.WARN,
+    "ERROR": logging.ERROR,
+    "FATAL": logging.FATAL,
 }[args.log_level]
 
 logging.basicConfig(level=log_level)
@@ -114,11 +113,12 @@ network = LxaNetwork(
     lss_address_cache_file=args.lss_address_cache_file,
 )
 
-app['network'] = network
+app["network"] = network
 
 
 async def shutdown_network(app):
-    await app['network'].shutdown()
+    await app["network"].shutdown()
+
 
 app.on_shutdown.append(shutdown_network)
 loop.create_task(network.run())
@@ -135,11 +135,12 @@ try:
 
 except OSError as e:
     if e.errno == errno.ENODEV:  # can interface not available
-        exit('interface {} not available'.format(args.interface))
+        exit("interface {} not available".format(args.interface))
 
 loop.create_task(server.flush_state_periodicly())
 
 if args.shell:
+
     def _start_shell():
         from traitlets.config import Config
         import IPython
@@ -153,15 +154,21 @@ if args.shell:
 
     loop.create_task(server.rpc.worker_pool.run(_start_shell))
 
-print('starting server on http://{}:{}/'.format(args.host, args.port))
+print("starting server on http://{}:{}/".format(args.host, args.port))
 
 try:
     kwargs = {}
     if args.log_level != "DEBUG":
         kwargs["access_log"] = None
-    run_app(app=app, host=args.host, port=args.port,
-            handle_signals=False, print=lambda *args, **kwargs: None,
-            loop=loop, **kwargs)
+    run_app(
+        app=app,
+        host=args.host,
+        port=args.port,
+        handle_signals=False,
+        print=lambda *args, **kwargs: None,
+        loop=loop,
+        **kwargs,
+    )
 
 except KeyboardInterrupt:
     server.shutdown()
@@ -169,9 +176,9 @@ except KeyboardInterrupt:
 
 except OSError:
     server.shutdown()
-    exit('ERROR: can not bind to port {}'.format(args.port))
+    exit("ERROR: can not bind to port {}".format(args.port))
 
-print('\rshutting down server')
+print("\rshutting down server")
 
 server.shutdown()
 os.kill(os.getpid(), signal.SIGTERM)

--- a/doc/source/architecture.rst
+++ b/doc/source/architecture.rst
@@ -47,10 +47,10 @@ The following figure shows the structure of the LXA IOBus system:
   current state of the bus and connected devices.
 * **Linux SocketCAN**:
   The LXA IOBus Server uses `SocketCAN <https://en.wikipedia.org/wiki/SocketCAN>`_
-  to interfact with the CAN-bus.
+  to interact with the CAN-bus.
 * **Node-specific electrical interface**:
-  Every LXA IOBus node has an application-specific specialiced electiral interface
+  Every LXA IOBus node has an application-specific specialised electrical interface
   that is designed to perform different automation tasks.
 * **CAN-Bus**:
   This is the actual electrical interface that connects server and nodes.
-  This is the same CAN bus inteface you may know from many automotive applications.
+  This is the same CAN bus interface you may know from many automotive applications.

--- a/doc/source/can_canopen.rst
+++ b/doc/source/can_canopen.rst
@@ -2,7 +2,7 @@ CAN Basics
 ==========
 
 CAN and CANopen are, when compared to modern Ethernet and IP,
-quite simple protcols.
+quite simple protocols.
 Most software developers are however more familiar with Ethernet
 and IP and less with CAN and CANopen.
 
@@ -62,7 +62,7 @@ Reliable transmission
 CAN makes a good amount of effort to make sure all nodes on the
 bus share a common understanding of the information transmitted:
 Every message contains a checksum to make sure no bit-errors
-occour on the bus.
+occur on the bus.
 
 Additionally all nodes on the bus do a handshake for every message
 that ensures that either all or no node received the message.
@@ -86,9 +86,9 @@ Let's take a look at the following scenarios:
   been received by any node.
   This can happen if there are only two nodes on a bus
   and one is not powered or disconnected due to a faulty
-  conenction.
+  connection.
 * **Two other nodes on the bus and the checksum is OK**:
-  Both receiving nodes send an acknowlege after the end
+  Both receiving nodes send an acknowledge after the end
   of the message.
   All three nodes assume that every other node has
   received the message correctly.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -17,9 +17,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'Linux Automation GmbH lxa-iobus-server'
-copyright = '2021, Chris Fiege'
-author = 'Chris Fiege'
+project = "Linux Automation GmbH lxa-iobus-server"
+copyright = "2021, Chris Fiege"
+author = "Chris Fiege"
 
 
 # -- General configuration ---------------------------------------------------
@@ -28,15 +28,15 @@ author = 'Chris Fiege'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-        "sphinx_rtd_theme",
-        "sphinx.ext.todo",
-        "sphinx.ext.autosectionlabel",
+    "sphinx_rtd_theme",
+    "sphinx.ext.todo",
+    "sphinx.ext.autosectionlabel",
 ]
 
 todo_include_todos = True
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -49,9 +49,9 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]

--- a/doc/source/getting_started.rst
+++ b/doc/source/getting_started.rst
@@ -58,7 +58,7 @@ a single LXA IOBus device:
 
    CAN structure for a single LXA IOBus device on a short bus.
    The 120Ω termination resistor is connected between CAN_H and CAN_L
-   and (for short busses) may be placed anywhere on the bus.
+   and (for short buses) may be placed anywhere on the bus.
 
 In this example the LXA IOBus device and the CAN adapter
 are the only devices on the CAN bus.
@@ -168,7 +168,7 @@ differential impedance should be used for the CAN bus.
 For GND and power supply use wires with a sufficient cross section to keep
 the power supply and CAN bus common mode voltage in the allowed ranges.
 
-For short busses flat ribbon cables present a cheap and easy-to-install
+For short buses flat ribbon cables present a cheap and easy-to-install
 alternative to UTP cabling.
 Plugs and sockets are available from many manufacturers, for example
 *L17DEFRA09P* and *L17DEFRA09S* from Amphenol.

--- a/doc/source/web.rst
+++ b/doc/source/web.rst
@@ -28,7 +28,7 @@ output are available.
 Read the manual for the specific node for more
 information on specific options.
 
-The following fiels are available for every node:
+The following fields are available for every node:
 
 * **Name:** The logical name for this device.
   This name is used to identify this node on the :term:`REST` interface.

--- a/lxa_iobus/__init__.py
+++ b/lxa_iobus/__init__.py
@@ -1,2 +1,2 @@
 VERSION = (0, 4, 2)
-VERSION_STRING = '{}'.format('.'.join([str(i) for i in VERSION]))
+VERSION_STRING = "{}".format(".".join([str(i) for i in VERSION]))

--- a/lxa_iobus/canopen.py
+++ b/lxa_iobus/canopen.py
@@ -1,9 +1,7 @@
 import struct
-
 from time import time
 
 from can import Message
-
 
 LSS_PROTOCOL_IDENTIFIER_SLAVE_TO_MASTER = 2020
 LSS_PROTOCOL_IDENTIFIER_MASTER_TO_SLAVE = 2021

--- a/lxa_iobus/canopen.py
+++ b/lxa_iobus/canopen.py
@@ -94,11 +94,6 @@ class SdoMessage:
             setattr(self, key, value)
 
 
-# lss_adresse: sowas wie mac adresse (wie eingebrannt)
-# id_number  : (unbekannt, kann man wahrscheinlich nicht verstehen)
-# node_id    : temporaere adresse auf dem bus (wie ip unter dhcp)
-
-
 def gen_lss_switch_mode_global_message(lss_mode):
     if lss_mode not in (LssMode.OPERATION, LssMode.CONFIGURATION):
         raise ValueError

--- a/lxa_iobus/canopen.py
+++ b/lxa_iobus/canopen.py
@@ -244,19 +244,11 @@ def gen_sdo_segment_download(node_id, toggle, complete, seg_data):
     if not isinstance(toggle, bool):
         raise ValueError
 
-    if toggle:
-        toggle = 1
-    else:
-        toggle = 0
-
     if not isinstance(complete, bool):
         raise ValueError
 
-    if complete:
-        complete = 1
-
-    else:
-        complete = 0
+    toggle = int(toggle)
+    complete = int(complete)
 
     if len(seg_data) not in range(0, 8):
         raise ValueError
@@ -311,11 +303,7 @@ def gen_sdo_segment_upload(node_id, toggle):
     if not isinstance(toggle, bool):
         raise ValueError
 
-    if toggle:
-        toggle = 1
-
-    else:
-        toggle = 0
+    toggle = int(toggle)
 
     return Message(
         timestamp=time(),

--- a/lxa_iobus/canopen.py
+++ b/lxa_iobus/canopen.py
@@ -15,9 +15,9 @@ LSS_COMMAND_SPECIFIER_IDENTIFY_SLAVE = 0x4F
 
 SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX = 0x600
 SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE = range(
-        SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX + 1,
-        SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX + 0b1111111 + 1)
-SDO_PROTCOL_IDENTIFIER_SLAVE_TO_MASTER = range(0x581, 0x5ff + 1)
+    SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX + 1, SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX + 0b1111111 + 1
+)
+SDO_PROTCOL_IDENTIFIER_SLAVE_TO_MASTER = range(0x581, 0x5FF + 1)
 
 # The length of the data is stored in the data field
 SDO_TRANSFER_TYPE_SIZE = 0b01
@@ -29,37 +29,37 @@ SDO_TRANSFER_TYPE_DATA_WITH_SIZE = 0b11
 SDO_TRANSFER_TYPE_DATA_NO_SIZE = 0b10
 
 SDO_ABORT_CODES = {
-    0x05030000: 'Toggle bit not alternated',
-    0x05040000: 'SDO protocol timed out',
-    0x05040001: 'Client/server command specifier not valid or unknown',
-    0x05040002: 'Invalid block size',
-    0x05040003: 'Invalid sequence number',
-    0x05040004: 'CRC error',
-    0x05040005: 'Out of memory',
-    0x06010000: 'Unsupported access to an object',
-    0x06010001: 'Attempt to read a write only object',
-    0x06010002: 'Attempt to write a read only object',
-    0x06020000: 'Object does not exist in the object dictionary',
-    0x06040041: 'Object cannot be mapped to the PDO',
-    0x06040042: 'The number and length of the objects to be mapped would exceed PDO length',  # NOQA
-    0x06040043: 'General parameter incompatibility reason',
-    0x06040047: 'General internal incompatibility in the device',
-    0x06060000: 'Access failed due to an hardware error',
-    0x06070010: 'Data type does not match, length of service parameter does not match',  # NOQA
-    0x06070012: 'Data type does not match, length of service parameter too high',  # NOQA
-    0x06070013: 'Data type does not match, length of service parameter too low',  # NOQA
-    0x06090011: 'Sub-index does not exist',
-    0x06090030: 'Invalid value for parameter',
-    0x06090031: 'Value of parameter written too high',
-    0x06090032: 'Value of parameter written too low',
-    0x06090036: 'Maximum value is less than minimum value',
-    0x060A0023: 'Resource not available: SDO connection',
-    0x08000000: 'General error',
-    0x08000020: 'Data cannot be transferred or stored to the application',
-    0x08000021: 'Data cannot be transferred or stored to the application because of local control',  # NOQA
-    0x08000022: 'Data cannot be transferred or stored to the application because of the present device state',  # NOQA
-    0x08000023: 'Object dictionary dynamic generation fails or no object dictionary is present',  # NOQA
-    0x08000024: 'No data available',
+    0x05030000: "Toggle bit not alternated",
+    0x05040000: "SDO protocol timed out",
+    0x05040001: "Client/server command specifier not valid or unknown",
+    0x05040002: "Invalid block size",
+    0x05040003: "Invalid sequence number",
+    0x05040004: "CRC error",
+    0x05040005: "Out of memory",
+    0x06010000: "Unsupported access to an object",
+    0x06010001: "Attempt to read a write only object",
+    0x06010002: "Attempt to write a read only object",
+    0x06020000: "Object does not exist in the object dictionary",
+    0x06040041: "Object cannot be mapped to the PDO",
+    0x06040042: "The number and length of the objects to be mapped would exceed PDO length",  # NOQA
+    0x06040043: "General parameter incompatibility reason",
+    0x06040047: "General internal incompatibility in the device",
+    0x06060000: "Access failed due to an hardware error",
+    0x06070010: "Data type does not match, length of service parameter does not match",  # NOQA
+    0x06070012: "Data type does not match, length of service parameter too high",  # NOQA
+    0x06070013: "Data type does not match, length of service parameter too low",  # NOQA
+    0x06090011: "Sub-index does not exist",
+    0x06090030: "Invalid value for parameter",
+    0x06090031: "Value of parameter written too high",
+    0x06090032: "Value of parameter written too low",
+    0x06090036: "Maximum value is less than minimum value",
+    0x060A0023: "Resource not available: SDO connection",
+    0x08000000: "General error",
+    0x08000020: "Data cannot be transferred or stored to the application",
+    0x08000021: "Data cannot be transferred or stored to the application because of local control",  # NOQA
+    0x08000022: "Data cannot be transferred or stored to the application because of the present device state",  # NOQA
+    0x08000023: "Object dictionary dynamic generation fails or no object dictionary is present",  # NOQA
+    0x08000024: "No data available",
 }
 
 
@@ -76,9 +76,9 @@ class SDO_Abort(Exception):
         self.error_code = error_code
 
     def __str__(self):
-        error_text = SDO_ABORT_CODES.get(self.error_code, '')
+        error_text = SDO_ABORT_CODES.get(self.error_code, "")
 
-        return 'SDO Abort: node: {} 0x{:02X}-0x{:02X} code: 0x{:08}: {}'.format(  # NOQA
+        return "SDO Abort: node: {} 0x{:02X}-0x{:02X} code: 0x{:08}: {}".format(  # NOQA
             self.node_id,
             self.index,
             self.sub_index,
@@ -109,30 +109,31 @@ def gen_lss_switch_mode_global_message(lss_mode):
         timestamp=time(),
         arbitration_id=LSS_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE,
         data=struct.pack(
-            '<BBxxxxxx',
+            "<BBxxxxxx",
             LSS_COMMAND_SPECIFIER_SWITCH_MODE_GLOBAL,
             lss_mode,
         ),
-        is_extended_id=False
+        is_extended_id=False,
     )
 
 
 def gen_lss_configure_node_id_message(node_id):
-    if(not isinstance(node_id, int) or  # only integer
-       node_id not in range(0, 128) or  # canopen ids from 0-127 are valid
-       node_id == 125):                 # reserved for the ISP (bootloader)
-
+    if (
+        not isinstance(node_id, int)
+        or node_id not in range(0, 128)  # only integer
+        or node_id == 125  # canopen ids from 0-127 are valid
+    ):  # reserved for the ISP (bootloader)
         raise ValueError
 
     return Message(
         timestamp=time(),
         arbitration_id=LSS_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE,
         data=struct.pack(
-            '<BBxxxxxx',
+            "<BBxxxxxx",
             LSS_COMMAND_SPECIFIER_CONFIGURE_NODE_ID,
             node_id,
         ),
-        is_extended_id=False
+        is_extended_id=False,
     )
 
 
@@ -141,47 +142,39 @@ def gen_invalidate_node_ids_message():
         timestamp=time(),
         arbitration_id=LSS_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE,
         data=struct.pack(
-            '<BBxxxxxx',
+            "<BBxxxxxx",
             LSS_COMMAND_SPECIFIER_CONFIGURE_NODE_ID,
             255,
         ),
-        is_extended_id=False
+        is_extended_id=False,
     )
 
 
 def gen_lss_fast_scan_message(id_number, bit_checked, lss_sub, lss_next):
-    if(not isinstance(id_number, int) or
-       id_number not in range(0, 2**32)):
-
+    if not isinstance(id_number, int) or id_number not in range(0, 2**32):
         raise ValueError
 
-    if(not isinstance(bit_checked, int) or
-       bit_checked not in range(0, 256)):
-
+    if not isinstance(bit_checked, int) or bit_checked not in range(0, 256):
         raise ValueError
 
-    if(not isinstance(lss_sub, int) or
-       lss_sub not in range(0, 256)):
-
+    if not isinstance(lss_sub, int) or lss_sub not in range(0, 256):
         raise ValueError
 
-    if(not isinstance(lss_next, int) or
-       lss_next not in range(0, 256)):
-
+    if not isinstance(lss_next, int) or lss_next not in range(0, 256):
         raise ValueError
 
     return Message(
         timestamp=time(),
         arbitration_id=LSS_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE,
         data=struct.pack(
-            '<BLBBB',
+            "<BLBBB",
             LSS_COMMAND_SPECIFIER_FAST_SCAN,
             id_number,
             bit_checked,
             lss_sub,
             lss_next,
         ),
-        is_extended_id=False
+        is_extended_id=False,
     )
 
 
@@ -217,10 +210,10 @@ def gen_sdo_initiate_download(node_id, type, index, sub_index, data):
     if type not in range(0, 4):
         raise ValueError
 
-    if index not in range(0, 0xffff + 1):
+    if index not in range(0, 0xFFFF + 1):
         raise ValueError
 
-    if sub_index not in range(0, 0xff + 1):
+    if sub_index not in range(0, 0xFF + 1):
         raise ValueError
 
     if len(data) not in range(0, 5):
@@ -232,13 +225,13 @@ def gen_sdo_initiate_download(node_id, type, index, sub_index, data):
         timestamp=time(),
         arbitration_id=SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX | node_id,
         data=struct.pack(
-            '<BHB4s',
+            "<BHB4s",
             (command_specifier << 5) | (n << 2) | type,
             index,
             sub_index,
             data,
         ),
-        is_extended_id=False
+        is_extended_id=False,
     )
 
 
@@ -276,7 +269,7 @@ def gen_sdo_segment_download(node_id, toggle, complete, seg_data):
         timestamp=time(),
         arbitration_id=SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX | node_id,
         data=struct.pack(
-            '<B7s',
+            "<B7s",
             (command_specifier << 5) | (toggle << 4) | (n << 1) | complete,
             seg_data,
         ),
@@ -289,21 +282,21 @@ def gen_sdo_initiate_upload(node_id, index, sub_index):
 
     command_specifier = 2
 
-    if index not in range(0, 0xffff + 1):
+    if index not in range(0, 0xFFFF + 1):
         raise ValueError
 
-    if sub_index not in range(0, 0xff + 1):
+    if sub_index not in range(0, 0xFF + 1):
         raise ValueError
 
     return Message(
         timestamp=time(),
         arbitration_id=SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX | node_id,
         data=struct.pack(
-            '<BHB4s',
+            "<BHB4s",
             (command_specifier << 5),
             index,
             sub_index,
-            b'',
+            b"",
         ),
         is_extended_id=False,
     )
@@ -330,9 +323,9 @@ def gen_sdo_segment_upload(node_id, toggle):
         timestamp=time(),
         arbitration_id=SDO_PROTCOL_IDENTIFIER_MASTER_TO_SLAVE_PREFIX | node_id,
         data=struct.pack(
-            '<B7s',
+            "<B7s",
             (command_specifier << 5) | (toggle << 4),
-            b'',
+            b"",
         ),
         is_extended_id=False,
     )
@@ -352,13 +345,12 @@ def parse_sdo_message(message):
         seg_data = message.data[1:]
 
         sdo_message_kwargs = {
-            'type': 'upload_segment',
-            'node_id': node_id,
-
-            'toggle': toggle,
-            'number_of_bytes_not_used': number_of_bytes_not_used,
-            'complete': complete,
-            'seg_data': seg_data,
+            "type": "upload_segment",
+            "node_id": node_id,
+            "toggle": toggle,
+            "number_of_bytes_not_used": number_of_bytes_not_used,
+            "complete": complete,
+            "seg_data": seg_data,
         }
 
     # download segment (server -> node)
@@ -366,73 +358,68 @@ def parse_sdo_message(message):
         toggle = ((message.data[0] >> 4) & 1) == 1
 
         sdo_message_kwargs = {
-            'type': 'download_segment',
-            'node_id': node_id,
-            'toggle': toggle,
+            "type": "download_segment",
+            "node_id": node_id,
+            "toggle": toggle,
         }
 
     # initiate upload (node -> server)
     elif command_specifier == 2:
-        sdo_message_kwargs['type'] = 'initiate_upload'
+        sdo_message_kwargs["type"] = "initiate_upload"
 
         number_of_bytes_not_used = (message.data[0] >> 2) & 0b11
         transfer_type = ((message.data[0] >> 1) & 1) == 1
         indicates_size = ((message.data[0] >> 0) & 1) == 1
 
-        index, subindex = struct.unpack('<xHBxxxx', message.data)
+        index, subindex = struct.unpack("<xHBxxxx", message.data)
         data = message.data[4:]
 
         # e s
         readable_transfer_type = {
-                (0, 0): 'Reserved',
-
-                # The length of the data is stored in the data field
-                (0, 1): 'Size',
-
-                # The length is stored in n and data in the data field
-                (1, 1): 'DataWithSize',
-
-                # No size is given and must be inverted from packet size
-                (1, 0): 'DataNoSize',
-            }[transfer_type, indicates_size]
+            (0, 0): "Reserved",
+            # The length of the data is stored in the data field
+            (0, 1): "Size",
+            # The length is stored in n and data in the data field
+            (1, 1): "DataWithSize",
+            # No size is given and must be inverted from packet size
+            (1, 0): "DataNoSize",
+        }[transfer_type, indicates_size]
 
         sdo_message_kwargs = {
-            'type': 'initiate_upload',
-            'node_id': node_id,
-
-            'number_of_bytes_not_used': number_of_bytes_not_used,
-            'transfer_type': transfer_type,
-            'indicates_size': indicates_size,
-            'index': index,
-            'subindex': subindex,
-            'data': data,
-            'readable_transfer_type': readable_transfer_type,
+            "type": "initiate_upload",
+            "node_id": node_id,
+            "number_of_bytes_not_used": number_of_bytes_not_used,
+            "transfer_type": transfer_type,
+            "indicates_size": indicates_size,
+            "index": index,
+            "subindex": subindex,
+            "data": data,
+            "readable_transfer_type": readable_transfer_type,
         }
 
     # initiate download (server -> node)
     elif command_specifier == 3:
-        index, subindex = struct.unpack('<xHBxxxx', message.data)
+        index, subindex = struct.unpack("<xHBxxxx", message.data)
 
         sdo_message_kwargs = {
-            'type': 'initiate_download',
-            'node_id': node_id,
-            'index': index,
-            'subindex': subindex,
+            "type": "initiate_download",
+            "node_id": node_id,
+            "index": index,
+            "subindex": subindex,
         }
 
     # abort
     elif command_specifier == 4:
-        index, subindex, error_code = struct.unpack('<xHBL', message.data)
+        index, subindex, error_code = struct.unpack("<xHBL", message.data)
 
         sdo_message_kwargs = {
-            'type': 'abort',
-            'node_id': node_id,
-
-            'index': index,
-            'subindex': subindex,
-            'error_code': error_code,
+            "type": "abort",
+            "node_id": node_id,
+            "index": index,
+            "subindex": subindex,
+            "error_code": error_code,
         }
 
-    sdo_message_kwargs['message'] = message
+    sdo_message_kwargs["message"] = message
 
     return SdoMessage(**sdo_message_kwargs)

--- a/lxa_iobus/canopen.py
+++ b/lxa_iobus/canopen.py
@@ -41,13 +41,13 @@ SDO_ABORT_CODES = {
     0x06010002: "Attempt to write a read only object",
     0x06020000: "Object does not exist in the object dictionary",
     0x06040041: "Object cannot be mapped to the PDO",
-    0x06040042: "The number and length of the objects to be mapped would exceed PDO length",  # NOQA
+    0x06040042: "The number and length of the objects to be mapped would exceed PDO length",
     0x06040043: "General parameter incompatibility reason",
     0x06040047: "General internal incompatibility in the device",
     0x06060000: "Access failed due to an hardware error",
-    0x06070010: "Data type does not match, length of service parameter does not match",  # NOQA
-    0x06070012: "Data type does not match, length of service parameter too high",  # NOQA
-    0x06070013: "Data type does not match, length of service parameter too low",  # NOQA
+    0x06070010: "Data type does not match, length of service parameter does not match",
+    0x06070012: "Data type does not match, length of service parameter too high",
+    0x06070013: "Data type does not match, length of service parameter too low",
     0x06090011: "Sub-index does not exist",
     0x06090030: "Invalid value for parameter",
     0x06090031: "Value of parameter written too high",
@@ -56,9 +56,9 @@ SDO_ABORT_CODES = {
     0x060A0023: "Resource not available: SDO connection",
     0x08000000: "General error",
     0x08000020: "Data cannot be transferred or stored to the application",
-    0x08000021: "Data cannot be transferred or stored to the application because of local control",  # NOQA
-    0x08000022: "Data cannot be transferred or stored to the application because of the present device state",  # NOQA
-    0x08000023: "Object dictionary dynamic generation fails or no object dictionary is present",  # NOQA
+    0x08000021: "Data cannot be transferred or stored to the application because of local control",
+    0x08000022: "Data cannot be transferred or stored to the application because of the present device state",
+    0x08000023: "Object dictionary dynamic generation fails or no object dictionary is present",
     0x08000024: "No data available",
 }
 
@@ -78,7 +78,7 @@ class SdoAbort(Exception):
     def __str__(self):
         error_text = SDO_ABORT_CODES.get(self.error_code, "")
 
-        return "SDO Abort: node: {} 0x{:02X}-0x{:02X} code: 0x{:08}: {}".format(  # NOQA
+        return "SDO Abort: node: {} 0x{:02X}-0x{:02X} code: 0x{:08}: {}".format(
             self.node_id,
             self.index,
             self.sub_index,
@@ -243,7 +243,7 @@ def gen_sdo_segment_download(node_id, toggle, complete, seg_data):
     if node_id not in range(0, 128):
         raise ValueError
 
-    if type(toggle) is not bool:
+    if not isinstance(toggle, bool):
         raise ValueError
 
     if toggle:
@@ -251,7 +251,7 @@ def gen_sdo_segment_download(node_id, toggle, complete, seg_data):
     else:
         toggle = 0
 
-    if not type(complete) is bool:
+    if not isinstance(complete, bool):
         raise ValueError
 
     if complete:
@@ -260,7 +260,7 @@ def gen_sdo_segment_download(node_id, toggle, complete, seg_data):
     else:
         complete = 0
 
-    if not len(seg_data) in range(0, 8):
+    if len(seg_data) not in range(0, 8):
         raise ValueError
 
     n = 7 - len(seg_data)
@@ -310,7 +310,7 @@ def gen_sdo_segment_upload(node_id, toggle):
     if node_id not in range(0, 128):
         raise ValueError
 
-    if type(toggle) is not bool:
+    if not isinstance(toggle, bool):
         raise ValueError
 
     if toggle:

--- a/lxa_iobus/lpc11xxcanisp/can_isp.py
+++ b/lxa_iobus/lpc11xxcanisp/can_isp.py
@@ -1,10 +1,10 @@
-from functools import partial
-from datetime import datetime
 import asyncio
 import logging
+import os
 import struct
 import time
-import os
+from datetime import datetime
+from functools import partial
 
 from lxa_iobus.lpc11xxcanisp import loader
 

--- a/lxa_iobus/lpc11xxcanisp/can_isp.py
+++ b/lxa_iobus/lpc11xxcanisp/can_isp.py
@@ -67,7 +67,7 @@ class IspCompareError(Exception):
 
 class CanIsp:
     DATA_SIZES = {8: "B", 16: "H", 32: "I"}
-    ram_offset = 0x10000500  # Offset to savely usable RAM
+    ram_offset = 0x10000500  # Offset to safely usable RAM
 
     object_directory = {
         "Device Type": [0x1000, 0, 32],
@@ -216,7 +216,7 @@ class CanIsp:
     def unlock(self):
         """
         Unlocks write operations
-        Needs to be called befor writing to RAM or Flash
+        Needs to be called before writing to RAM or Flash
         """
 
         self.send("Unlock Code", 23130)
@@ -258,12 +258,12 @@ class CanIsp:
         self.send("Copy Length", length)
 
     def go(self, addr):
-        """Jumps to given addresse"""
+        """Jumps to given address"""
 
         self.send("Execution Address", addr)
         self.send("Program Control", 1)  # Trigger jump
 
-    def erase_flash_secotrs(self, start, stop):
+    def erase_flash_sectors(self, start, stop):
         """Clear given flash range"""
 
         if stop < start:
@@ -318,7 +318,7 @@ class CanIsp:
 
         return self._get(obj[0], obj[1], None)  # Get uint32 as bytearray
 
-    def compare(self, addr_1, addr_2, lenght):
+    def compare(self, addr_1, addr_2, length):
         """
         Takes two addresses and a length and compare the data.
         Raises IspCompareError if a mismatch is found.
@@ -327,7 +327,7 @@ class CanIsp:
         try:
             self.send("Compare Address 1", addr_1)
             self.send("Compare Address 2", addr_2)
-            self.send("Compare Length", lenght)
+            self.send("Compare Length", length)
 
         except IspSdoAbortedError as e:
             if e.str() == "COMPARE_ERROR":
@@ -336,7 +336,7 @@ class CanIsp:
                 raise IspCompareError(offset) from e
 
     def flash_image(self, start, data):
-        logging.info("Data to be writen: %d Byte", len(data))
+        logging.info("Data to be written: %d Byte", len(data))
 
         block_size = 4096
 
@@ -347,7 +347,7 @@ class CanIsp:
 
         # data must be multiple of block size
         # TODO add option for smaller block size
-        #      Supporte are: 256, 512, 1024, 4096.
+        #      Supported are: 256, 512, 1024, 4096.
 
         stuffing = len(data) % block_size
 
@@ -355,12 +355,12 @@ class CanIsp:
             logging.info("Date buffer is extended by %d", stuffing)
             data += b"\xff" * (block_size - stuffing)
 
-        logging.info("Data to be writen %d Bytes", len(data))
+        logging.info("Data to be written %d Bytes", len(data))
         logging.info("Start sector %d", start_sector)
 
         sectors = len(data) // block_size
 
-        assert (len(data) % block_size) == 0, "Need to erease extra sector to fit date: %d" % len(data)
+        assert (len(data) % block_size) == 0, "Need to erase extra sector to fit date: %d" % len(data)
 
         logging.info("Sectors to write %d", sectors)
 
@@ -373,10 +373,10 @@ class CanIsp:
             start_sector + sectors - 1,
         )
 
-        # TODO: Add check if we need to erease block use Blank check sectors
+        # TODO: Add check if we need to erase block use Blank check sectors
         self.unlock()  # Unlock writes
         self.prepare_flash_sectors(start_sector, start_sector + sectors - 1)
-        self.erase_flash_secotrs(start_sector, start_sector + sectors - 1)
+        self.erase_flash_sectors(start_sector, start_sector + sectors - 1)
 
         blocks = sectors
 
@@ -404,9 +404,9 @@ class CanIsp:
     # helper methods ##########################################################
     def fix_checksum(self, data):
         """
-        This generate the checksum in the vectro table.
-        This is needed for the LPC11CXX und probebly all Cortex-M0.
-        and is normaly done somewhere in the swd programming chain.
+        This generate the checksum in the vector table.
+        This is needed for the LPC11CXX und probably all Cortex-M0.
+        and is normally done somewhere in the swd programming chain.
         For more info see: UM10398 26.3.3 Criterion for Valid User Code.
         """
         # First 7 entries:

--- a/lxa_iobus/lpc11xxcanisp/can_isp.py
+++ b/lxa_iobus/lpc11xxcanisp/can_isp.py
@@ -424,7 +424,8 @@ class CanIsp:
     def write(self, filename, section):
         assert section in ["config", "flash"]
 
-        data = open(filename, "rb").read()
+        with open(filename, "rb") as fd:
+            data = fd.read()
 
         if section == "flash":
             data = self.fix_checksum(data)
@@ -490,13 +491,15 @@ class CanIsp:
             "Bytes/sec",
         )
 
-        open(filename, "wb").write(data)
+        with open(filename, "wb") as fd:
+            fd.write(data)
 
     def write_flash(self, filename):
         self.write(filename, "flash")
 
     def isp_exec(self, filename):
-        data = open(filename, "rb").read()
+        with open(filename, "rb") as fd:
+            data = fd.read()
 
         self.unlock()
         self.write_to_ram(0x10000500, data)

--- a/lxa_iobus/lpc11xxcanisp/can_isp.py
+++ b/lxa_iobus/lpc11xxcanisp/can_isp.py
@@ -282,7 +282,7 @@ class CanIsp:
 
         return self.get("Program Area")
 
-    def read_partID(self) -> int:
+    def read_part_id(self) -> int:
         """
         Returns a tuple with the part id and the part name if known
         otherwise None
@@ -410,7 +410,7 @@ class CanIsp:
         For more info see: UM10398 26.3.3 Criterion for Valid User Code.
         """
 
-        vector_table = data[0 : 4 * 7]  # First 7 entrys
+        vector_table = data[0 : 4 * 7]  # First 7 entries
         vector_table = struct.unpack("iiiiiii", vector_table)
 
         checksum = 0 - (sum(vector_table))

--- a/lxa_iobus/lpc11xxcanisp/can_isp.py
+++ b/lxa_iobus/lpc11xxcanisp/can_isp.py
@@ -333,7 +333,7 @@ class CanIsp:
             if e.str() == "COMPARE_ERROR":
                 offset = self.get("Compare mismatch")
 
-                raise IspCompareError(offset)
+                raise IspCompareError(offset) from e
 
     def flash_image(self, start, data):
         logging.info("Data to be writen: %d Byte", len(data))
@@ -409,8 +409,9 @@ class CanIsp:
         and is normaly done somewhere in the swd programming chain.
         For more info see: UM10398 26.3.3 Criterion for Valid User Code.
         """
+        # First 7 entries:
+        vector_table = data[0 : 4 * 7]
 
-        vector_table = data[0 : 4 * 7]  # First 7 entries
         vector_table = struct.unpack("iiiiiii", vector_table)
 
         checksum = 0 - (sum(vector_table))
@@ -438,9 +439,7 @@ class CanIsp:
 
         if len(data) > length:
             self.console_log(
-                "Supplied Image is too long for section. Allowed {} bytes, is {} bytes".format(  # NOQA
-                    length, len(data)
-                )
+                "Supplied Image is too long for section. Allowed {} bytes, is {} bytes".format(length, len(data))
             )
 
             exit(1)

--- a/lxa_iobus/lpc11xxcanisp/can_isp.py
+++ b/lxa_iobus/lpc11xxcanisp/can_isp.py
@@ -17,22 +17,22 @@ class ExceptionCanIsp(Exception):
 
 class IspSdoAbortedError(Exception):
     abort_codes = {
-        0x0F00000D: 'ADDR_ERROR',
-        0x0F00000E: 'ADDR_NOT_MAPPED',
-        0x0F00000F: 'CMD_LOCKED',
-        0x0F000013: 'CODE_READ_PROTECTION_ENABLED',
-        0x0F00000A: 'COMPARE_ERROR',
-        0x0F000006: 'COUNT_ERROR',
-        0x0F000003: 'DST_ADDR_ERROR',
-        0x0F000005: 'DST_ADDR_NOT_MAPPED',
-        0x0F000010: 'INVALID_CODE',
-        0x0F000001: 'INVALID_COMMAND',
-        0x0F000007: 'INVALID_SECTOR',
-        0x0F00000C: 'PARAM_ERROR',
-        0x0F000008: 'SECTOR_NOT_BLANK',
-        0x0F000009: 'SECTOR_NOT_PREPARED_FOR_WRITE_OPERATION',
-        0x0F000002: 'SRC_ADDR_ERROR',
-        0x0F000004: 'SRC_ADDR_NOT_MAPPED'
+        0x0F00000D: "ADDR_ERROR",
+        0x0F00000E: "ADDR_NOT_MAPPED",
+        0x0F00000F: "CMD_LOCKED",
+        0x0F000013: "CODE_READ_PROTECTION_ENABLED",
+        0x0F00000A: "COMPARE_ERROR",
+        0x0F000006: "COUNT_ERROR",
+        0x0F000003: "DST_ADDR_ERROR",
+        0x0F000005: "DST_ADDR_NOT_MAPPED",
+        0x0F000010: "INVALID_CODE",
+        0x0F000001: "INVALID_COMMAND",
+        0x0F000007: "INVALID_SECTOR",
+        0x0F00000C: "PARAM_ERROR",
+        0x0F000008: "SECTOR_NOT_BLANK",
+        0x0F000009: "SECTOR_NOT_PREPARED_FOR_WRITE_OPERATION",
+        0x0F000002: "SRC_ADDR_ERROR",
+        0x0F000004: "SRC_ADDR_NOT_MAPPED",
     }
 
     def __init__(self, code):
@@ -46,11 +46,11 @@ class IspSdoAbortedError(Exception):
         return self.abort_codes.get(self.code, None)
 
     def __str__(self):
-        text = 'Code 0x{:08X}'.format(self.code)
+        text = "Code 0x{:08X}".format(self.code)
         reason = self.str()
 
         if reason is not None:
-            text += ', ' + reason
+            text += ", " + reason
 
         return text
 
@@ -60,81 +60,75 @@ class IspCompareError(Exception):
         self.offset = offset
 
     def __str__(self):
-        text = 'Memory compare failed at 0x{:08X}'.format(self.offset)
+        text = "Memory compare failed at 0x{:08X}".format(self.offset)
 
         return text
 
 
 class CanIsp:
-    DATA_SIZES = {8: 'B', 16: 'H', 32: 'I'}
+    DATA_SIZES = {8: "B", 16: "H", 32: "I"}
     ram_offset = 0x10000500  # Offset to savely usable RAM
 
     object_directory = {
-        'Device Type': [0x1000, 0, 32],
-        'Vendor ID': [0x1018, 1, 32],  # Not used: should be 0
-        'Part Identification Number': [0x1018, 2, 32],
-        'Boot Code Version Number': [0x1018, 3, 32],
-        'Program Area': [0x1F50, 1, None],  # DOMAIN
-        'Program Control': [0x1F51, 1, 8],
-        'Unlock Code': [0x5000, 0, 16],
-
-        'Memory Read Address': [0x5010, 0, 32],
-        'Memory Read Length': [0x5011, 0, 32],
-
-        'RAM Write Address': [0x5015, 0, 32],
-
-        'Prepare Sectors for Write': [0x5020, 0, 16],
-        'Erase Sectors': [0x5030, 0, 16],
-
-        'Check sectors': [0x5040, 1, 16],
-
-        'Copy Flash Address': [0x5050, 1, 32],
-        'Copy RAM Address': [0x5050, 2, 32],
-        'Copy Length': [0x5050, 3, 16],
-
-        'Compare Address 1': [0x5060, 1, 32],
-        'Compare Address 2': [0x5060, 2, 32],
-        'Compare Length': [0x5060, 3, 16],
-        'Compare mismatch': [0x5060, 4, 32],
-        'Execution Address': [0x5070, 1, 32],
-        'Serial Number 1': [0x5100, 1, 32],
-        'Serial Number 2': [0x5100, 2, 32],
-        'Serial Number 3': [0x5100, 3, 32],
-        'Serial Number 4': [0x5100, 4, 32]
+        "Device Type": [0x1000, 0, 32],
+        "Vendor ID": [0x1018, 1, 32],  # Not used: should be 0
+        "Part Identification Number": [0x1018, 2, 32],
+        "Boot Code Version Number": [0x1018, 3, 32],
+        "Program Area": [0x1F50, 1, None],  # DOMAIN
+        "Program Control": [0x1F51, 1, 8],
+        "Unlock Code": [0x5000, 0, 16],
+        "Memory Read Address": [0x5010, 0, 32],
+        "Memory Read Length": [0x5011, 0, 32],
+        "RAM Write Address": [0x5015, 0, 32],
+        "Prepare Sectors for Write": [0x5020, 0, 16],
+        "Erase Sectors": [0x5030, 0, 16],
+        "Check sectors": [0x5040, 1, 16],
+        "Copy Flash Address": [0x5050, 1, 32],
+        "Copy RAM Address": [0x5050, 2, 32],
+        "Copy Length": [0x5050, 3, 16],
+        "Compare Address 1": [0x5060, 1, 32],
+        "Compare Address 2": [0x5060, 2, 32],
+        "Compare Length": [0x5060, 3, 16],
+        "Compare mismatch": [0x5060, 4, 32],
+        "Execution Address": [0x5070, 1, 32],
+        "Serial Number 1": [0x5100, 1, 32],
+        "Serial Number 2": [0x5100, 2, 32],
+        "Serial Number 3": [0x5100, 3, 32],
+        "Serial Number 4": [0x5100, 4, 32],
     }
 
     part_ids = {
-        0x041E502B: 'LPC1111FHN33/101',
-        0x2516D02B: 'LPC1111FHN33/102',
-        0x0416502B: 'LPC1111FHN33/201',
-        0x2516902B: 'LPC1111FHN33/202',
-        0x00010013: 'LPC1111FHN33/103',
-        0x00010012: 'LPC1111FHN33/203',
-        0x042D502B: 'LPC1112FHN33/101',
-        0x2524D02B: 'LPC1112FHN33/102',
-        0x0425502B: 'LPC1112FHN33/201',
-        0x2524902B: 'LPC1112FHI33/202',
-        0x00020023: 'LPC1112FHN33/103',
-        0x00020022: 'LPC1112FHI33/203',
-        0x0434502B: 'LPC1113FHN33/201',
-        0x2532902B: 'LPC1113FHN33/202',
-        0x0434102B: 'LPC1113FBD48/301',
-        0x2532102B: 'LPC1113FBD48/302',
-        0x00030032: 'LPC1113FHN33/203',
-        0x00030030: 'LPC1113FHN33/303',
-        0x0444502B: 'LPC1114FHN33/201',
-        0x2540902B: 'LPC1114FHN33/202',
-        0x0444102B: 'LPC1114FBD48/301',
-        0x00040042: 'LPC1114FHN33/203',
-        0x00040060: 'LPC1114FBD48/323',
-        0x00040070: 'LPC1114FHN33/333',
-        0x00040040: 'LPC1114FHI33/303',
-        0x2540102B: 'LPC11D14FBD100/302',
-        0x00050080: 'LPC1115FBD48/303',
-        0x1421102B: 'LPC11C12FBD48/301',
-        0x1440102B: 'LPC11C14FBD48/301',
-        0x1431102B: 'LPC11C22FBD48/301',
-        0x1430102B: 'LPC11C24FBD48/301'
+        0x041E502B: "LPC1111FHN33/101",
+        0x2516D02B: "LPC1111FHN33/102",
+        0x0416502B: "LPC1111FHN33/201",
+        0x2516902B: "LPC1111FHN33/202",
+        0x00010013: "LPC1111FHN33/103",
+        0x00010012: "LPC1111FHN33/203",
+        0x042D502B: "LPC1112FHN33/101",
+        0x2524D02B: "LPC1112FHN33/102",
+        0x0425502B: "LPC1112FHN33/201",
+        0x2524902B: "LPC1112FHI33/202",
+        0x00020023: "LPC1112FHN33/103",
+        0x00020022: "LPC1112FHI33/203",
+        0x0434502B: "LPC1113FHN33/201",
+        0x2532902B: "LPC1113FHN33/202",
+        0x0434102B: "LPC1113FBD48/301",
+        0x2532102B: "LPC1113FBD48/302",
+        0x00030032: "LPC1113FHN33/203",
+        0x00030030: "LPC1113FHN33/303",
+        0x0444502B: "LPC1114FHN33/201",
+        0x2540902B: "LPC1114FHN33/202",
+        0x0444102B: "LPC1114FBD48/301",
+        0x00040042: "LPC1114FHN33/203",
+        0x00040060: "LPC1114FBD48/323",
+        0x00040070: "LPC1114FHN33/333",
+        0x00040040: "LPC1114FHI33/303",
+        0x2540102B: "LPC11D14FBD100/302",
+        0x00050080: "LPC1115FBD48/303",
+        0x1421102B: "LPC11C12FBD48/301",
+        0x1440102B: "LPC11C14FBD48/301",
+        0x1431102B: "LPC11C22FBD48/301",
+        0x1430102B: "LPC11C24FBD48/301",
     }
 
     def __init__(self, server, network):
@@ -146,18 +140,15 @@ class CanIsp:
     def console_log(self, *message):
         console_max_len = 100
 
-        message = '{}: {}'.format(
-            str(datetime.now()),
-            ' '.join([str(i) for i in message])
-        )
+        message = "{}: {}".format(str(datetime.now()), " ".join([str(i) for i in message]))
 
         self._console.append(message)
 
         if len(self._console) > console_max_len:
-            self._console = self._console[len(self._console)-console_max_len:]
+            self._console = self._console[len(self._console) - console_max_len :]
 
         self.server.rpc.worker_pool.run_sync(
-            partial(self.server.rpc.notify, 'isp_console', self._console),
+            partial(self.server.rpc.notify, "isp_console", self._console),
             wait=False,
         )
 
@@ -228,7 +219,7 @@ class CanIsp:
         Needs to be called befor writing to RAM or Flash
         """
 
-        self.send("Unlock Code",  23130)
+        self.send("Unlock Code", 23130)
 
     def write_to_ram(self, addr: int, data: bytes):
         """Writes data to RAM at addr"""
@@ -236,8 +227,8 @@ class CanIsp:
         # TODO: Check if we override the bootloader area
         # TODO: Check RAM Size
 
-        self.send('RAM Write Address', addr)
-        self.send('Program Area', data)
+        self.send("RAM Write Address", addr)
+        self.send("Program Area", data)
 
     def prepare_flash_sectors(self, start: int, stop: int):
         """
@@ -249,15 +240,12 @@ class CanIsp:
         """
 
         if stop < start:
-            raise ExceptionCanIsp('Sector range not ascending')
+            raise ExceptionCanIsp("Sector range not ascending")
 
         if start > 8 or stop > 8:
-            raise ExceptionCanIsp('Sector out of range')
+            raise ExceptionCanIsp("Sector out of range")
 
-        self.send(
-            'Prepare Sectors for Write',
-            ((start & 0xff) | ((stop & 0xff) << 8))
-        )
+        self.send("Prepare Sectors for Write", ((start & 0xFF) | ((stop & 0xFF) << 8)))
 
     def copy_ram_to_flash(self, ram_addr, flash_addr, length):
         """Copies RAM range to flash"""
@@ -265,34 +253,34 @@ class CanIsp:
         # TODO: Check for alignment
         # TODO: Check FLASH size
 
-        self.send('Copy Flash Address', flash_addr)
-        self.send('Copy RAM Address', ram_addr)
-        self.send('Copy Length', length)
+        self.send("Copy Flash Address", flash_addr)
+        self.send("Copy RAM Address", ram_addr)
+        self.send("Copy Length", length)
 
     def go(self, addr):
         """Jumps to given addresse"""
 
-        self.send('Execution Address', addr)
-        self.send('Program Control', 1)  # Trigger jump
+        self.send("Execution Address", addr)
+        self.send("Program Control", 1)  # Trigger jump
 
     def erase_flash_secotrs(self, start, stop):
         """Clear given flash range"""
 
         if stop < start:
-            raise ExceptionCanIsp('Sector range not ascending')
+            raise ExceptionCanIsp("Sector range not ascending")
 
         if start > 8 or stop > 8:
-            raise ExceptionCanIsp('Sector out of range')
+            raise ExceptionCanIsp("Sector out of range")
 
-        self.send('Erase Sectors', ((start & 0xff) | ((stop & 0xff) << 8)))
+        self.send("Erase Sectors", ((start & 0xFF) | ((stop & 0xFF) << 8)))
 
     def read_memory(self, addr: int, length: int) -> bytes:
         """Dumps part of the MCUs memory"""
 
-        self.send('Memory Read Address', addr)
-        self.send('Memory Read Length', length)
+        self.send("Memory Read Address", addr)
+        self.send("Memory Read Length", length)
 
-        return self.get('Program Area')
+        return self.get("Program Area")
 
     def read_partID(self) -> int:
         """
@@ -300,7 +288,7 @@ class CanIsp:
         otherwise None
         """
 
-        part_id = self.get('Part Identification Number')
+        part_id = self.get("Part Identification Number")
         part_name = self.part_ids.get(part_id, None)
 
         return (part_id, part_name)
@@ -308,7 +296,7 @@ class CanIsp:
     def read_bootloader_version(self) -> int:
         """Returns bootloader version as an 32-bit unsigned integers"""
 
-        return self.get('Boot Code Version Number')
+        return self.get("Boot Code Version Number")
 
     def read_serial_number(self) -> [int]:
         """
@@ -317,16 +305,16 @@ class CanIsp:
         """
 
         return [
-            self.get('Serial Number 1'),
-            self.get('Serial Number 2'),
-            self.get('Serial Number 3'),
-            self.get('Serial Number 4'),
+            self.get("Serial Number 1"),
+            self.get("Serial Number 2"),
+            self.get("Serial Number 3"),
+            self.get("Serial Number 4"),
         ]
 
     def read_device_type(self) -> bytes:
         """The device type should always be 'LPC1'"""
 
-        obj = self.object_directory['Device Type']
+        obj = self.object_directory["Device Type"]
 
         return self._get(obj[0], obj[1], None)  # Get uint32 as bytearray
 
@@ -337,25 +325,25 @@ class CanIsp:
         """
 
         try:
-            self.send('Compare Address 1', addr_1)
-            self.send('Compare Address 2', addr_2)
-            self.send('Compare Length', lenght)
+            self.send("Compare Address 1", addr_1)
+            self.send("Compare Address 2", addr_2)
+            self.send("Compare Length", lenght)
 
         except IspSdoAbortedError as e:
-            if e.str() == 'COMPARE_ERROR':
-                offset = self.get('Compare mismatch')
+            if e.str() == "COMPARE_ERROR":
+                offset = self.get("Compare mismatch")
 
                 raise IspCompareError(offset)
 
     def flash_image(self, start, data):
-        logging.info('Data to be writen: %d Byte', len(data))
+        logging.info("Data to be writen: %d Byte", len(data))
 
         block_size = 4096
 
         if (start % block_size) != 0:
-            raise Exception('Start must be a multiple of 4096!')
+            raise Exception("Start must be a multiple of 4096!")
 
-        start_sector = start//block_size
+        start_sector = start // block_size
 
         # data must be multiple of block size
         # TODO add option for smaller block size
@@ -364,53 +352,52 @@ class CanIsp:
         stuffing = len(data) % block_size
 
         if stuffing != 0:
-            logging.info('Date buffer is extended by %d', stuffing)
-            data += b'\xff'*(block_size-stuffing)
+            logging.info("Date buffer is extended by %d", stuffing)
+            data += b"\xff" * (block_size - stuffing)
 
-        logging.info('Data to be writen %d Bytes', len(data))
-        logging.info('Start sector %d', start_sector)
+        logging.info("Data to be writen %d Bytes", len(data))
+        logging.info("Start sector %d", start_sector)
 
         sectors = len(data) // block_size
 
-        assert (len(data) % block_size) == 0, \
-            'Need to erease extra sector to fit date: %d' % len(data)
+        assert (len(data) % block_size) == 0, "Need to erease extra sector to fit date: %d" % len(data)
 
-        logging.info('Sectors to write %d', sectors)
+        logging.info("Sectors to write %d", sectors)
 
         if start_sector + sectors > 8:
-            raise Exception('Data to write does not fit into flash are of 32k')
+            raise Exception("Data to write does not fit into flash are of 32k")
 
         logging.info(
-            'Erasing blocks %d to %d',
+            "Erasing blocks %d to %d",
             start_sector,
-            start_sector+sectors-1,
+            start_sector + sectors - 1,
         )
 
         # TODO: Add check if we need to erease block use Blank check sectors
         self.unlock()  # Unlock writes
-        self.prepare_flash_sectors(start_sector, start_sector+sectors-1)
-        self.erase_flash_secotrs(start_sector, start_sector+sectors-1)
+        self.prepare_flash_sectors(start_sector, start_sector + sectors - 1)
+        self.erase_flash_secotrs(start_sector, start_sector + sectors - 1)
 
         blocks = sectors
 
-        for block_num in range(start_sector, start_sector+blocks):
-            logging.info('Send block %d', block_num)
+        for block_num in range(start_sector, start_sector + blocks):
+            logging.info("Send block %d", block_num)
 
-            start_offset = block_size*(block_num-start_sector)
+            start_offset = block_size * (block_num - start_sector)
 
-            block = data[start_offset: start_offset + block_size]
-            logging.info('Block length %d', len(block))
+            block = data[start_offset : start_offset + block_size]
+            logging.info("Block length %d", len(block))
 
             # Transfer data block to the RAM of the MCU
             self.write_to_ram(self.ram_offset, block)
 
-            logging.info('Copy to Flash')
+            logging.info("Copy to Flash")
             self.prepare_flash_sectors(block_num, block_num)
 
             # Copy block from MCU RAM to MCU Flash
             self.copy_ram_to_flash(
                 self.ram_offset,
-                block_size*block_num,
+                block_size * block_num,
                 block_size,
             )
 
@@ -423,25 +410,25 @@ class CanIsp:
         For more info see: UM10398 26.3.3 Criterion for Valid User Code.
         """
 
-        vector_table = data[0:4*7]  # First 7 entrys
-        vector_table = struct.unpack('iiiiiii', vector_table)
+        vector_table = data[0 : 4 * 7]  # First 7 entrys
+        vector_table = struct.unpack("iiiiiii", vector_table)
 
-        checksum = 0-(sum(vector_table))
-        checksum = struct.pack('i', checksum)
+        checksum = 0 - (sum(vector_table))
+        checksum = struct.pack("i", checksum)
 
-        data = data[0:4*7] + checksum + data[4*8:]
+        data = data[0 : 4 * 7] + checksum + data[4 * 8 :]
 
         return data
 
     def write(self, filename, section):
-        assert(section in ['config', 'flash'])
+        assert section in ["config", "flash"]
 
-        data = open(filename, 'rb').read()
+        data = open(filename, "rb").read()
 
-        if section == 'flash':
+        if section == "flash":
             data = self.fix_checksum(data)
 
-        if section == 'flash':
+        if section == "flash":
             length = 28 * 1024
             start = 0
         else:
@@ -451,15 +438,14 @@ class CanIsp:
 
         if len(data) > length:
             self.console_log(
-                'Supplied Image is too long for section. Allowed {} bytes, is {} bytes'.format(  # NOQA
-                    length,
-                    len(data)
+                "Supplied Image is too long for section. Allowed {} bytes, is {} bytes".format(  # NOQA
+                    length, len(data)
                 )
             )
 
             exit(1)
 
-        self.console_log('Writing section {}'.format(section))
+        self.console_log("Writing section {}".format(section))
         start_t = time.time()
 
         self.flash_image(start, data)
@@ -467,19 +453,19 @@ class CanIsp:
         stop_t = time.time()
 
         self.console_log(
-            'Write',
+            "Write",
             len(data),
-            'in',
-            stop_t-start_t,
-            ':',
-            len(data) / (stop_t-start_t),
-            'Bytes/sec',
+            "in",
+            stop_t - start_t,
+            ":",
+            len(data) / (stop_t - start_t),
+            "Bytes/sec",
         )
 
     def read(self, filename, section):
-        assert(section in ['config', 'flash'])
+        assert section in ["config", "flash"]
 
-        if section == 'flash':
+        if section == "flash":
             length = 28 * 1024
             start = 0
 
@@ -488,7 +474,7 @@ class CanIsp:
             length = 4 * 1024
             start = 28 * 1024
 
-        self.console_log('Reading section {}'.format(section))
+        self.console_log("Reading section {}".format(section))
         start_t = time.time()
 
         data = self.read_memory(start, length)
@@ -496,26 +482,26 @@ class CanIsp:
         stop_t = time.time()
 
         self.console_log(
-            'Read',
+            "Read",
             length,
-            'in',
-            stop_t-start_t,
-            ':',
-            length / (stop_t-start_t),
-            'Bytes/sec',
+            "in",
+            stop_t - start_t,
+            ":",
+            length / (stop_t - start_t),
+            "Bytes/sec",
         )
 
-        open(filename, 'wb').write(data)
+        open(filename, "wb").write(data)
 
     def write_flash(self, filename):
-        self.write(filename, 'flash')
+        self.write(filename, "flash")
 
     def isp_exec(self, filename):
-        data = open(filename, 'rb').read()
+        data = open(filename, "rb").read()
 
         self.unlock()
         self.write_to_ram(0x10000500, data)
         self.go(0x10000500)
 
     def reset(self):
-        self.isp_exec(os.path.join(basepath, 'loader/reset.bin'))
+        self.isp_exec(os.path.join(basepath, "loader/reset.bin"))

--- a/lxa_iobus/lpc11xxcanisp/firmware/versions.py
+++ b/lxa_iobus/lpc11xxcanisp/firmware/versions.py
@@ -1,6 +1,6 @@
 import os
 
-from lxa_iobus.node_drivers import PTXIOMuxDriver, Iobus4Do3Di3AiDriver, EthernetMuxDriver
+from lxa_iobus.node_drivers import EthernetMuxDriver, Iobus4Do3Di3AiDriver, PTXIOMuxDriver
 
 FIRMWARE_DIR = os.path.dirname(__file__)
 

--- a/lxa_iobus/lpc11xxcanisp/firmware/versions.py
+++ b/lxa_iobus/lpc11xxcanisp/firmware/versions.py
@@ -7,14 +7,14 @@ FIRMWARE_DIR = os.path.dirname(__file__)
 FIRMWARE_VERSIONS = {
     PTXIOMuxDriver: (
         (0, 3, 0),
-        os.path.join(FIRMWARE_DIR, 'ptxtac-S03_CAN_GPIO.bin'),
+        os.path.join(FIRMWARE_DIR, "ptxtac-S03_CAN_GPIO.bin"),
     ),
     Iobus4Do3Di3AiDriver: (
         (0, 5, 0),
-        os.path.join(FIRMWARE_DIR, 'lxatac_can_io-t01.bin'),
+        os.path.join(FIRMWARE_DIR, "lxatac_can_io-t01.bin"),
     ),
     EthernetMuxDriver: (
         (0, 5, 0),
-        os.path.join(FIRMWARE_DIR, 'ethmux-S01.bin'),
+        os.path.join(FIRMWARE_DIR, "ethmux-S01.bin"),
     ),
 }

--- a/lxa_iobus/network.py
+++ b/lxa_iobus/network.py
@@ -276,8 +276,8 @@ class LxaNetwork:
     async def fast_scan_request(self, lss_id, bit_checked, lss_sub, lss_next):
         # TODO: check if we got the correct response
 
-        # FIXME: sleep wird gebraucht weil RX nicht clean ist.
-        # wir krigen Pakete vom der letzten anfrage
+        # FIXME: sleep is required because RX may not be clean
+        # and we may still get replies from the previous request.
 
         response = await self.lss_request(
             gen_lss_fast_scan_message(lss_id, bit_checked, lss_sub, lss_next),
@@ -317,11 +317,11 @@ class LxaNetwork:
         fast_scan_request: fast_scan_request method
         start: Start value for the LSS address (default: [0, 0, 0, 0])
         mask: Only bits that are 0 are going to be tested.
-              (dafault: [0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff])
+              (default: [0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff])
 
         returns:
           None: No node could be selected
-          LSS Adress
+          LSS Address
         """
 
         if start is None:
@@ -366,7 +366,7 @@ class LxaNetwork:
 
         # Final select
         if not await self.fast_scan_request(lss_id[3], 0, 3, 0):
-            logger.debug("fast_scan: Final round fail ")
+            logger.debug("fast_scan: Final round fail")
 
             return None
 

--- a/lxa_iobus/network.py
+++ b/lxa_iobus/network.py
@@ -1,28 +1,27 @@
-from copy import deepcopy
-import itertools
 import asyncio
-import logging
-import time
-import json
-import os
-import errno
 import enum
+import errno
+import itertools
+import json
+import logging
+import os
 import signal
+import time
+from copy import deepcopy
 
-from janus import Queue, SyncQueueEmpty
 from can import Bus, CanError
+from janus import Queue, SyncQueueEmpty
 
 from lxa_iobus.canopen import (
-    gen_lss_switch_mode_global_message,
-    gen_invalidate_node_ids_message,
-    gen_lss_fast_scan_message,
-    gen_lss_configure_node_id_message,
     LSS_PROTOCOL_IDENTIFIER_SLAVE_TO_MASTER,
     SDO_PROTOCOL_IDENTIFIER_SLAVE_TO_MASTER,
-    parse_sdo_message,
     LssMode,
+    gen_invalidate_node_ids_message,
+    gen_lss_configure_node_id_message,
+    gen_lss_fast_scan_message,
+    gen_lss_switch_mode_global_message,
+    parse_sdo_message,
 )
-
 from lxa_iobus.node import LxaNode
 
 logger = logging.getLogger("lx-iobus.network")

--- a/lxa_iobus/network.py
+++ b/lxa_iobus/network.py
@@ -58,8 +58,12 @@ class LxaNetwork:
     def interface_is_up(self):
         path = os.path.join("/sys/class/net/", self.interface, "operstate")
 
-        if os.path.exists(path) and open(path, "r").read().strip() in ["up", "unknown"]:
-            return True
+        if os.path.exists(path):
+            with open(path, "r") as fd:
+                state = fd.read()
+
+            if state.strip() in ["up", "unknown"]:
+                return True
 
         return False
 

--- a/lxa_iobus/network.py
+++ b/lxa_iobus/network.py
@@ -18,10 +18,10 @@ from lxa_iobus.canopen import (
     gen_invalidate_node_ids_message,
     gen_lss_fast_scan_message,
     gen_lss_configure_node_id_message,
-    LSS_PROTCOL_IDENTIFIER_SLAVE_TO_MASTER,
-    SDO_PROTCOL_IDENTIFIER_SLAVE_TO_MASTER,
+    LSS_PROTOCOL_IDENTIFIER_SLAVE_TO_MASTER,
+    SDO_PROTOCOL_IDENTIFIER_SLAVE_TO_MASTER,
     parse_sdo_message,
-    LSS_MODE,
+    LssMode,
 )
 
 from lxa_iobus.node import LxaNode
@@ -218,11 +218,11 @@ class LxaNetwork:
                 logger.debug("rx: %s", str(message))
 
                 # lss messages
-                if message.arbitration_id == LSS_PROTCOL_IDENTIFIER_SLAVE_TO_MASTER:
+                if message.arbitration_id == LSS_PROTOCOL_IDENTIFIER_SLAVE_TO_MASTER:
                     self._lss_set_response(message)
 
                 # sdo message
-                elif message.arbitration_id in SDO_PROTCOL_IDENTIFIER_SLAVE_TO_MASTER:
+                elif message.arbitration_id in SDO_PROTOCOL_IDENTIFIER_SLAVE_TO_MASTER:
                     sdo_message = parse_sdo_message(message)
                     node_id = sdo_message.node_id
 
@@ -417,7 +417,7 @@ class LxaNetwork:
     async def lss_fast_scan(self):
         try:
             response = await self.lss_request(
-                gen_lss_switch_mode_global_message(LSS_MODE.CONFIGURATION),
+                gen_lss_switch_mode_global_message(LssMode.CONFIGURATION),
             )
 
             if not response:
@@ -431,7 +431,7 @@ class LxaNetwork:
                 logger.debug("fast_scan: No response to invalidate_node_IDs")
 
             response = await self.lss_request(
-                gen_lss_switch_mode_global_message(LSS_MODE.OPERATION),
+                gen_lss_switch_mode_global_message(LssMode.OPERATION),
             )
 
             if not response:
@@ -484,7 +484,7 @@ class LxaNetwork:
 
                 self._sdo_queues[node_id] = Queue()
 
-                response = await self.lss_request(gen_lss_switch_mode_global_message(LSS_MODE.OPERATION))
+                response = await self.lss_request(gen_lss_switch_mode_global_message(LssMode.OPERATION))
 
                 if not response:
                     logger.debug("fast_scan: Setting node ID not working")

--- a/lxa_iobus/network.py
+++ b/lxa_iobus/network.py
@@ -8,7 +8,6 @@ import os
 import errno
 import enum
 import signal
-import sys
 
 from janus import Queue, SyncQueueEmpty
 from can import Bus, CanError
@@ -558,7 +557,7 @@ class LxaNetwork:
         return self.nodes[125]
 
     def get_node_by_name(self, name):
-        for node_id, node in self.nodes.copy().items():
+        for _, node in self.nodes.copy().items():
             if node.name == name:
                 return node
 

--- a/lxa_iobus/node.py
+++ b/lxa_iobus/node.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent
+import contextlib
 import logging
 import os
 import struct
@@ -169,7 +170,7 @@ class LxaNode:
                 if not response.type == "upload_segment":
                     raise Exception("Got wrong answer: {}".format(response.type))
 
-                if not toggle == response.toggle:
+                if toggle != response.toggle:
                     Exception(
                         "Toggle bit does not match: is: {}, should: {}".format(
                             response.toggle,
@@ -426,8 +427,5 @@ class LxaNode:
         self.locator_state = state
 
     async def invoke_isp(self):
-        try:
+        with contextlib.suppress(TimeoutError):
             await self.sdo_write(0x2B07, 0, struct.pack("I", 0x12345678))
-
-        except TimeoutError:
-            pass

--- a/lxa_iobus/node.py
+++ b/lxa_iobus/node.py
@@ -1,23 +1,22 @@
-import concurrent
 import asyncio
+import concurrent
 import logging
-import struct
 import os
-
-from lxa_iobus.lpc11xxcanisp.firmware.versions import FIRMWARE_VERSIONS
-from lxa_iobus.node_input import Input, Output, ADC
-from lxa_iobus.node_drivers import drivers
-from lxa_iobus.utils import array2int
+import struct
 
 from lxa_iobus.canopen import (
     SDO_TRANSFER_TYPE_DATA_WITH_SIZE,
-    gen_sdo_initiate_download,
-    gen_sdo_segment_download,
-    gen_sdo_initiate_upload,
     SDO_TRANSFER_TYPE_SIZE,
-    gen_sdo_segment_upload,
     SdoAbort,
+    gen_sdo_initiate_download,
+    gen_sdo_initiate_upload,
+    gen_sdo_segment_download,
+    gen_sdo_segment_upload,
 )
+from lxa_iobus.lpc11xxcanisp.firmware.versions import FIRMWARE_VERSIONS
+from lxa_iobus.node_drivers import drivers
+from lxa_iobus.node_input import ADC, Input, Output
+from lxa_iobus.utils import array2int
 
 DEFAULT_TIMEOUT = 1
 

--- a/lxa_iobus/node.py
+++ b/lxa_iobus/node.py
@@ -193,12 +193,12 @@ class LxaNode:
 
     async def sdo_write(self, index, sub_index, data, timeout=DEFAULT_TIMEOUT):
         async with self._lock:
-            #  * normal(Segment) transfare > 4 byte: multiple transactions
+            #  * normal(Segment) transfer > 4 byte: multiple transactions
             #  * expedited <= 4 byte: one transaction
 
             if len(data) <= 4:
                 #######################################
-                # expedited transfare
+                # expedited transfer
                 message = gen_sdo_initiate_download(
                     node_id=self.node_id,
                     index=index,
@@ -229,10 +229,10 @@ class LxaNode:
                 return
 
             ########################################
-            # Segment transfare
+            # Segment transfer
             transfer_size = len(data)
 
-            # Send the length of the transfare
+            # Send the length of the transfer
             message = gen_sdo_initiate_download(
                 node_id=self.node_id,
                 index=index,

--- a/lxa_iobus/node.py
+++ b/lxa_iobus/node.py
@@ -115,7 +115,7 @@ class LxaNode:
 
             if response.index != index or response.subindex != sub_index:
                 raise Exception(
-                    "Got answer to the wrong data object: Is: {}-{} , Should: {}-{}".format(  # NOQA
+                    "Got answer to the wrong data object: Is: {}-{} , Should: {}-{}".format(
                         response.index,
                         response.subindex,
                         index,

--- a/lxa_iobus/node.py
+++ b/lxa_iobus/node.py
@@ -16,7 +16,7 @@ from lxa_iobus.canopen import (
     gen_sdo_initiate_upload,
     SDO_TRANSFER_TYPE_SIZE,
     gen_sdo_segment_upload,
-    SDO_Abort,
+    SdoAbort,
 )
 
 DEFAULT_TIMEOUT = 1
@@ -88,7 +88,7 @@ class LxaNode:
     async def sdo_read(self, index, sub_index, timeout=DEFAULT_TIMEOUT):
         async with self._lock:
             # Depending on the answer we do:
-            #  * normal(Segment) transfare > 4 byte: multiple transactions
+            #  * normal(Segment) transfer > 4 byte: multiple transactions
             #  * expedited <= 4 byte: one transaction
             message = gen_sdo_initiate_upload(
                 node_id=self.node_id,
@@ -103,7 +103,7 @@ class LxaNode:
 
             # Something went wrong on the node side
             if response.type == "abort":
-                raise SDO_Abort(
+                raise SdoAbort(
                     node_id=response.node_id,
                     index=response.index,
                     sub_index=response.subindex,
@@ -132,10 +132,10 @@ class LxaNode:
             if response.readable_transfer_type == "DataNoSize":
                 return response.data
 
-            # Segmented transfare
+            # Segmented transfer
             # We get the size of data to come
             if not response.readable_transfer_type == "Size":
-                raise Exception("Unknown transfare type")
+                raise Exception("Unknown transfer type")
 
             transfer_size = struct.unpack("<L", response.data)[0]
 
@@ -160,7 +160,7 @@ class LxaNode:
                     raise TimeoutError
 
                 if response.type == "abort":
-                    raise SDO_Abort(
+                    raise SdoAbort(
                         node_id=response.node_id,
                         index=response.index,
                         sub_index=response.subindex,
@@ -216,7 +216,7 @@ class LxaNode:
                     raise TimeoutError
 
                 if response.type == "abort":
-                    raise SDO_Abort(
+                    raise SdoAbort(
                         node_id=response.node_id,
                         index=response.index,
                         sub_index=response.subindex,
@@ -250,7 +250,7 @@ class LxaNode:
                 raise TimeoutError
 
             if response.type == "abort":
-                raise SDO_Abort(
+                raise SdoAbort(
                     node_id=response.node_id,
                     index=response.index,
                     sub_index=response.subindex,
@@ -293,7 +293,7 @@ class LxaNode:
                     raise TimeoutError
 
                 if response.type == "abort":
-                    raise SDO_Abort(
+                    raise SdoAbort(
                         node_id=response.node_id,
                         index=response.index,
                         sub_index=response.subindex,
@@ -310,7 +310,7 @@ class LxaNode:
                 toggle ^= True
                 transfer_size -= length
 
-            # Maybe the complete flag is not corectly set
+            # Maybe the complete flag is not correctly set
             raise Exception("Something went wrong with segmented download")
 
     # public API ##############################################################
@@ -375,7 +375,7 @@ class LxaNode:
                 # vendor-specific fields fails.
                 try:
                     value = await self.sdo_read(sdo, sub_idx)
-                except SDO_Abort:
+                except SdoAbort:
                     continue
 
                 if field_type is int:

--- a/lxa_iobus/node_drivers.py
+++ b/lxa_iobus/node_drivers.py
@@ -21,7 +21,7 @@ class Pin:
 
     async def write(self, value):
         if self.pin_type != "output":
-            raise RuntimeError("Attemped to write to an {} channel".format(self.pin_type))
+            raise RuntimeError("Attempted to write to an {} channel".format(self.pin_type))
 
         value = value << self.bit
         mask = 1 << self.bit
@@ -63,7 +63,7 @@ class NodeDriver:
 class Iobus4Do3Di3AiDriver(NodeDriver):
     """LXA IOBus 4DO-3DI-3AI driver
 
-    The follwing pins are provided by this driver:
+    The following pins are provided by this driver:
 
       - OUT0-OUT3: Digital outputs
       - IN0-IN2: Digital inputs
@@ -98,7 +98,7 @@ class PTXIOMuxDriver(NodeDriver):
     This board is deprecated by the 4DO-3DI-3AI and does
     not get any firmware upgrades.
 
-    The follwing pins are provided by this driver:
+    The following pins are provided by this driver:
 
       - OUT0-OUT3: Digital outputs
       - IN4-IN6: Digital inputs
@@ -130,7 +130,7 @@ class PTXIOMuxDriver(NodeDriver):
 class EthernetMuxDriver(NodeDriver):
     """LXA Ethernet-Mux node driver
 
-    The follwing pins are provided by this driver:
+    The following pins are provided by this driver:
 
       - SW: Switch between Ethernet port A and B
       - SW_EXT: Status of the GPIO override input

--- a/lxa_iobus/node_drivers.py
+++ b/lxa_iobus/node_drivers.py
@@ -39,7 +39,7 @@ class NodeDriver:
     # public api ##############################################################
     @classmethod
     def match(cls, node):
-        driver_addr = [cls.LSS_VENDOR, cls.LSS_PRODUCT, cls.LSS_REVISON]
+        driver_addr = [cls.LSS_VENDOR, cls.LSS_PRODUCT, cls.LSS_REVISION]
 
         # Construct a human-readable device name from a driver
         # specific prefix and the zero-padded decimal serial number
@@ -73,7 +73,7 @@ class Iobus4Do3Di3AiDriver(NodeDriver):
 
     LSS_VENDOR = 0x507
     LSS_PRODUCT = 2
-    LSS_REVISON = 3
+    LSS_REVISION = 3
     NAME_PREFIX = "4DO-3DI-3AI-00005."
 
     def _get_pins(self):
@@ -108,7 +108,7 @@ class PTXIOMuxDriver(NodeDriver):
 
     LSS_VENDOR = 0
     LSS_PRODUCT = 4
-    LSS_REVISON = 1
+    LSS_REVISION = 1
     NAME_PREFIX = "PTXIOMux-00004."
 
     def _get_pins(self):
@@ -139,7 +139,7 @@ class EthernetMuxDriver(NodeDriver):
 
     LSS_VENDOR = 0x507
     LSS_PRODUCT = 1
-    LSS_REVISON = 4
+    LSS_REVISION = 4
     NAME_PREFIX = "Ethernet-Mux-00012."
 
     def _get_pins(self):

--- a/lxa_iobus/node_drivers.py
+++ b/lxa_iobus/node_drivers.py
@@ -6,24 +6,22 @@ class Pin:
         self.bit = bit
 
     async def read(self):
-        if self.pin_type == 'input':
+        if self.pin_type == "input":
             channel_state = await self.node.inputs[self.channel].read()
             pin_state = (channel_state >> self.bit) & 1
 
-        elif self.pin_type == 'output':
+        elif self.pin_type == "output":
             channel_state = await self.node.outputs[self.channel].read()
             pin_state = (channel_state >> self.bit) & 1
 
-        elif self.pin_type == 'adc':
+        elif self.pin_type == "adc":
             pin_state = await self.node.adcs[self.channel].read()
 
         return pin_state
 
     async def write(self, value):
-        if self.pin_type != 'output':
-            raise RuntimeError(
-                'Attemped to write to an {} channel'.format(self.pin_type)
-            )
+        if self.pin_type != "output":
+            raise RuntimeError("Attemped to write to an {} channel".format(self.pin_type))
 
         value = value << self.bit
         mask = 1 << self.bit
@@ -46,14 +44,14 @@ class NodeDriver:
         # Construct a human-readable device name from a driver
         # specific prefix and the zero-padded decimal serial number
         if node.lss_address[:3] == driver_addr:
-            serial = '{:05}'.format(node.lss_address[3])
+            serial = "{:05}".format(node.lss_address[3])
             return cls.NAME_PREFIX + serial
 
         return None
 
     @property
     def pins(self):
-        if not hasattr(self, '_pins'):
+        if not hasattr(self, "_pins"):
             self._pins = {}
 
         if not self._pins:
@@ -63,7 +61,7 @@ class NodeDriver:
 
 
 class Iobus4Do3Di3AiDriver(NodeDriver):
-    '''LXA IOBus 4DO-3DI-3AI driver
+    """LXA IOBus 4DO-3DI-3AI driver
 
     The follwing pins are provided by this driver:
 
@@ -71,31 +69,31 @@ class Iobus4Do3Di3AiDriver(NodeDriver):
       - IN0-IN2: Digital inputs
       - VIN: IOBus supply voltage
       - AIN0-AIN2: Analog inputs
-    '''
+    """
 
     LSS_VENDOR = 0x507
     LSS_PRODUCT = 2
     LSS_REVISON = 3
-    NAME_PREFIX = '4DO-3DI-3AI-00005.'
+    NAME_PREFIX = "4DO-3DI-3AI-00005."
 
     def _get_pins(self):
         return {
-            'OUT0': Pin(self.node, 'output', 0, 0),
-            'OUT1': Pin(self.node, 'output', 0, 1),
-            'OUT2': Pin(self.node, 'output', 0, 2),
-            'OUT3': Pin(self.node, 'output', 0, 3),
-            'IN0': Pin(self.node, 'input', 0, 0),
-            'IN1': Pin(self.node, 'input', 0, 1),
-            'IN2': Pin(self.node, 'input', 0, 2),
-            'VIN': Pin(self.node, 'adc', 0, None),
-            'AIN0': Pin(self.node, 'adc', 1, None),
-            'AIN1': Pin(self.node, 'adc', 2, None),
-            'AIN2': Pin(self.node, 'adc', 3, None),
+            "OUT0": Pin(self.node, "output", 0, 0),
+            "OUT1": Pin(self.node, "output", 0, 1),
+            "OUT2": Pin(self.node, "output", 0, 2),
+            "OUT3": Pin(self.node, "output", 0, 3),
+            "IN0": Pin(self.node, "input", 0, 0),
+            "IN1": Pin(self.node, "input", 0, 1),
+            "IN2": Pin(self.node, "input", 0, 2),
+            "VIN": Pin(self.node, "adc", 0, None),
+            "AIN0": Pin(self.node, "adc", 1, None),
+            "AIN1": Pin(self.node, "adc", 2, None),
+            "AIN2": Pin(self.node, "adc", 3, None),
         }
 
 
 class PTXIOMuxDriver(NodeDriver):
-    '''PTXTAC CAN IO extender Driver
+    """PTXTAC CAN IO extender Driver
 
     This board is deprecated by the 4DO-3DI-3AI and does
     not get any firmware upgrades.
@@ -106,60 +104,61 @@ class PTXIOMuxDriver(NodeDriver):
       - IN4-IN6: Digital inputs
       - AIN0-AIN2: Analog inputs
       - VIN: IOBus supply voltage
-    '''
+    """
 
     LSS_VENDOR = 0
     LSS_PRODUCT = 4
     LSS_REVISON = 1
-    NAME_PREFIX = 'PTXIOMux-00004.'
+    NAME_PREFIX = "PTXIOMux-00004."
 
     def _get_pins(self):
         return {
-            'OUT0': Pin(self.node, 'output', 0, 0),
-            'OUT1': Pin(self.node, 'output', 0, 1),
-            'OUT2': Pin(self.node, 'output', 0, 2),
-            'OUT3': Pin(self.node, 'output', 0, 3),
-            'IN4': Pin(self.node, 'input', 0, 0),
-            'IN5': Pin(self.node, 'input', 0, 1),
-            'IN6': Pin(self.node, 'input', 0, 2),
-            'AIN0': Pin(self.node, 'adc', 0, None),
-            'AIN1': Pin(self.node, 'adc', 1, None),
-            'AIN2': Pin(self.node, 'adc', 2, None),
-            'VIN': Pin(self.node, 'adc', 3, None),
+            "OUT0": Pin(self.node, "output", 0, 0),
+            "OUT1": Pin(self.node, "output", 0, 1),
+            "OUT2": Pin(self.node, "output", 0, 2),
+            "OUT3": Pin(self.node, "output", 0, 3),
+            "IN4": Pin(self.node, "input", 0, 0),
+            "IN5": Pin(self.node, "input", 0, 1),
+            "IN6": Pin(self.node, "input", 0, 2),
+            "AIN0": Pin(self.node, "adc", 0, None),
+            "AIN1": Pin(self.node, "adc", 1, None),
+            "AIN2": Pin(self.node, "adc", 2, None),
+            "VIN": Pin(self.node, "adc", 3, None),
         }
 
 
 class EthernetMuxDriver(NodeDriver):
-    '''LXA Ethernet-Mux node driver
+    """LXA Ethernet-Mux node driver
 
     The follwing pins are provided by this driver:
 
       - SW: Switch between Ethernet port A and B
       - SW_EXT: Status of the GPIO override input
       - VIN: IOBus supply voltage
-    '''
+    """
 
     LSS_VENDOR = 0x507
     LSS_PRODUCT = 1
     LSS_REVISON = 4
-    NAME_PREFIX = 'Ethernet-Mux-00012.'
+    NAME_PREFIX = "Ethernet-Mux-00012."
 
     def _get_pins(self):
         return {
-            'SW': Pin(self.node, 'output', 0, 0),
-            'SW_IN': Pin(self.node, 'input', 0, 0),
-            'SW_EXT': Pin(self.node, 'input', 0, 1),
-            'AIN0': Pin(self.node, 'adc', 0, None),
-            'VIN': Pin(self.node, 'adc', 1, None),
+            "SW": Pin(self.node, "output", 0, 0),
+            "SW_IN": Pin(self.node, "input", 0, 0),
+            "SW_EXT": Pin(self.node, "input", 0, 1),
+            "AIN0": Pin(self.node, "adc", 0, None),
+            "VIN": Pin(self.node, "adc", 1, None),
         }
 
+
 class DummyDriver(NodeDriver):
-    '''Catch-all dummy driver
+    """Catch-all dummy driver
 
     This driver does not provide any pins and matches on any address.
-    '''
+    """
 
-    NAME_PREFIX = 'Dummy-'
+    NAME_PREFIX = "Dummy-"
 
     @classmethod
     def match(cls, node):

--- a/lxa_iobus/node_input.py
+++ b/lxa_iobus/node_input.py
@@ -12,12 +12,12 @@ class Input:
         self.node = node
 
     async def get_pin_count(self):
-        pin_count = await self.node.sdo_read(self.INDEX, (self.channel*2)+1)
+        pin_count = await self.node.sdo_read(self.INDEX, (self.channel * 2) + 1)
         pin_count = array2int(pin_count)
         self.pins = pin_count
 
     async def read(self):
-        tmp = await self.node.sdo_read(self.INDEX, (self.channel*2+2))
+        tmp = await self.node.sdo_read(self.INDEX, (self.channel * 2 + 2))
 
         return array2int(tmp)
 
@@ -39,17 +39,17 @@ class Output(Input):
 
     async def write(self, mask, data):
         self.output_state = (self.output_state & (~mask)) | (data & mask)
-        data = int2array(((mask & 0xffff) << 16) | (data & 0xffff))
+        data = int2array(((mask & 0xFFFF) << 16) | (data & 0xFFFF))
         data = bytearray(data)
 
-        await self.node.sdo_write(self.INDEX, (self.channel*2+2), data)
+        await self.node.sdo_write(self.INDEX, (self.channel * 2 + 2), data)
 
     async def restore_state(self):
-        await self.write(0xffff, self.output_state)
+        await self.write(0xFFFF, self.output_state)
 
 
 class ADC:
-    INDEX = 0x2adc
+    INDEX = 0x2ADC
 
     def __init__(self, address, channel, node):
         self.address = address
@@ -59,13 +59,11 @@ class ADC:
         self.offset = 0
 
     async def get_config(self):
-        scale = await self.node.sdo_read(
-            self.INDEX, ((self.channel+1) << 2)+2)
+        scale = await self.node.sdo_read(self.INDEX, ((self.channel + 1) << 2) + 2)
 
         scale = struct.unpack("<f", scale)[0]
 
-        offset = await self.node.sdo_read(
-            self.INDEX, ((self.channel+1) << 2)+1)
+        offset = await self.node.sdo_read(self.INDEX, ((self.channel + 1) << 2) + 1)
 
         offset = struct.unpack("<i", offset)[0]
 
@@ -73,10 +71,10 @@ class ADC:
         self.scale = scale
 
     async def read(self):
-        tmp = await self.node.sdo_read(self.INDEX, ((self.channel+1) << 2))
+        tmp = await self.node.sdo_read(self.INDEX, ((self.channel + 1) << 2))
         tmp = struct.unpack("<H", tmp)[0]
 
-        return (tmp+self.offset)*self.scale
+        return (tmp + self.offset) * self.scale
 
     def info(self):
         return {

--- a/lxa_iobus/server/server.py
+++ b/lxa_iobus/server/server.py
@@ -131,7 +131,7 @@ class LXAIOBusServer:
                 callback = partial(self.can_isp.write_flash, file_name)
                 await self.loop.run_in_executor(None, callback)
 
-                self.can_isp.console_log("Reseting node")
+                self.can_isp.console_log("Resetting node")
                 await self.loop.run_in_executor(None, self.can_isp.reset)
 
                 self.can_isp.console_log("Flashing done")
@@ -707,7 +707,7 @@ class LXAIOBusServer:
     def flush_state_sync(self, wait=True):
         self.rpc.worker_pool.run_sync(partial(self.rpc.notify, "state", pformat(self.state)), wait=wait)
 
-    async def flush_state_periodicly(self):
+    async def flush_state_periodically(self):
         while self._running:
             await self.flush_state()
             await asyncio.sleep(1)

--- a/lxa_iobus/server/server.py
+++ b/lxa_iobus/server/server.py
@@ -1,20 +1,19 @@
-from concurrent.futures import CancelledError
-from functools import partial
-from datetime import datetime
-from pprint import pformat
 import asyncio
-import logging
 import json
+import logging
 import os
+from concurrent.futures import CancelledError
+from datetime import datetime
+from functools import partial
+from pprint import pformat
 
-from aiohttp.web import FileResponse, Response, HTTPFound, json_response
+from aiohttp.web import FileResponse, HTTPFound, Response, json_response
 from aiohttp_json_rpc import JsonRpc
 
 from lxa_iobus.lpc11xxcanisp.can_isp import CanIsp
-
 from lxa_iobus.lpc11xxcanisp.firmware.versions import (
-    FIRMWARE_VERSIONS,
     FIRMWARE_DIR,
+    FIRMWARE_VERSIONS,
 )
 
 STATIC_ROOT = os.path.join(os.path.dirname(__file__), "static")

--- a/lxa_iobus/server/server.py
+++ b/lxa_iobus/server/server.py
@@ -17,8 +17,8 @@ from lxa_iobus.lpc11xxcanisp.firmware.versions import (
     FIRMWARE_DIR,
 )
 
-STATIC_ROOT = os.path.join(os.path.dirname(__file__), 'static')
-logger = logging.getLogger('LXAIOBusServer')
+STATIC_ROOT = os.path.join(os.path.dirname(__file__), "static")
+logger = logging.getLogger("LXAIOBusServer")
 
 
 class LXAIOBusServer:
@@ -29,74 +29,67 @@ class LXAIOBusServer:
         self.firmware_directory = firmware_directory
         self.allow_custom_firmware = allow_custom_firmware
 
-        self.state = {
-            'low_level_nodes': {},
-            'low_level_nodes_state': {},
-            'nodes': {}
-        }
+        self.state = {"low_level_nodes": {}, "low_level_nodes_state": {}, "nodes": {}}
 
         self.started = datetime.now()
 
         # setup aiohttp
         self.rpc = JsonRpc(loop=self.loop, max_workers=6)
         self.worker_pool = self.rpc.worker_pool
-        app['rpc'] = self.rpc
+        app["rpc"] = self.rpc
 
         self.rpc.add_topics(
-            ('state',),
-            ('firmware',),
-            ('isp_console',),
+            ("state",),
+            ("firmware",),
+            ("isp_console",),
         )
 
-        app.router.add_route(
-            '*', '/static/{path_info:.*}', self.static)
+        app.router.add_route("*", "/static/{path_info:.*}", self.static)
 
-        app.router.add_route('*', '/', self.index)
-        self.app.router.add_route('*', '/rpc/', self.rpc)
+        app.router.add_route("*", "/", self.index)
+        self.app.router.add_route("*", "/rpc/", self.rpc)
 
         # rest api
-        app.router.add_route('GET', '/server-info/', self.get_server_info)
-        app.router.add_route('GET', '/nodes/{node}/pins/{pin}/', self.get_pin)
-        app.router.add_route('POST', '/nodes/{node}/pins/{pin}/', self.set_pin)
-        app.router.add_route('GET', '/nodes/{node}/pins/', self.get_pins)
+        app.router.add_route("GET", "/server-info/", self.get_server_info)
+        app.router.add_route("GET", "/nodes/{node}/pins/{pin}/", self.get_pin)
+        app.router.add_route("POST", "/nodes/{node}/pins/{pin}/", self.set_pin)
+        app.router.add_route("GET", "/nodes/{node}/pins/", self.get_pins)
 
-        app.router.add_route('POST', '/nodes/{node}/toggle-locator/',
-                             self.toggle_locator)
+        app.router.add_route("POST", "/nodes/{node}/toggle-locator/", self.toggle_locator)
 
-        app.router.add_route('GET', '/nodes/{node}/pin-info/',
-                             self.get_pin_info)
+        app.router.add_route("GET", "/nodes/{node}/pin-info/", self.get_pin_info)
 
-        app.router.add_route('GET', '/nodes/', self.get_nodes)
-        app.router.add_route('GET', '/nodes/{node}/', self.get_node)
+        app.router.add_route("GET", "/nodes/", self.get_nodes)
+        app.router.add_route("GET", "/nodes/{node}/", self.get_node)
 
         # firmware urls
         app.router.add_route(
-            'POST',
-            '/nodes/{node}/flash-firmware/{source}/{file_name}',
+            "POST",
+            "/nodes/{node}/flash-firmware/{source}/{file_name}",
             self.firmware_flash,
         )
 
         app.router.add_route(
-            'POST',
-            '/nodes/{node}/update/',
+            "POST",
+            "/nodes/{node}/update/",
             self.firmware_update,
         )
 
         app.router.add_route(
-            'GET',
-            '/firmware/',
+            "GET",
+            "/firmware/",
             self.get_firmware_files,
         )
 
         app.router.add_route(
-            'POST',
-            '/firmware/upload/',
+            "POST",
+            "/firmware/upload/",
             self.firmware_upload,
         )
 
         app.router.add_route(
-            'POST',
-            '/firmware/delete/{file_name}',
+            "POST",
+            "/firmware/delete/{file_name}",
             self.firmware_delete,
         )
 
@@ -126,57 +119,55 @@ class LXAIOBusServer:
                     return
 
                 self.can_isp.console_log(
-                    'Flashing {} ({})'.format(
+                    "Flashing {} ({})".format(
                         node.name,
                         node.address,
                     )
                 )
 
-                self.can_isp.console_log('Invoking isp')
+                self.can_isp.console_log("Invoking isp")
                 await node.invoke_isp()
 
-                self.can_isp.console_log('Start flashing')
+                self.can_isp.console_log("Start flashing")
                 callback = partial(self.can_isp.write_flash, file_name)
                 await self.loop.run_in_executor(None, callback)
 
-                self.can_isp.console_log('Reseting node')
+                self.can_isp.console_log("Reseting node")
                 await self.loop.run_in_executor(None, self.can_isp.reset)
 
-                self.can_isp.console_log('Flashing done')
+                self.can_isp.console_log("Flashing done")
 
             except CancelledError:
                 return
 
             except Exception:
-                logger.exception('flashing failed')
+                logger.exception("flashing failed")
 
     # views ###################################################################
     async def get_server_info(self, request):
         response = {
-            'hostname': os.uname()[1],
-            'started': str(self.started),
-            'can_interface': self.network.interface,
-            'can_interface_is_up': self.network.interface_is_up(),
-            'lss_state': self.network.lss_state.value,
-            'can_tx_error': self.network.tx_error,
+            "hostname": os.uname()[1],
+            "started": str(self.started),
+            "can_interface": self.network.interface,
+            "can_interface_is_up": self.network.interface_is_up(),
+            "lss_state": self.network.lss_state.value,
+            "can_tx_error": self.network.tx_error,
         }
-        headers = {
-            'Access-Control-Allow-Origin': '*'
-        }
+        headers = {"Access-Control-Allow-Origin": "*"}
 
         return json_response(response, headers=headers)
 
     async def index(self, request):
-        return FileResponse(os.path.join(STATIC_ROOT, 'index.html'))
+        return FileResponse(os.path.join(STATIC_ROOT, "index.html"))
 
     async def static(self, request):
         path = os.path.join(
             STATIC_ROOT,
-            os.path.relpath(request.path, '/static/'),
+            os.path.relpath(request.path, "/static/"),
         )
 
         if not os.path.exists(path):
-            return Response(text='404: not found', status=404)
+            return Response(text="404: not found", status=404)
 
         return FileResponse(path)
 
@@ -190,30 +181,28 @@ class LXAIOBusServer:
             nodes.append(node.name)
 
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': nodes,
+            "code": 0,
+            "error_message": "",
+            "result": nodes,
         }
-        headers = {
-            'Access-Control-Allow-Origin': '*'
-        }
+        headers = {"Access-Control-Allow-Origin": "*"}
 
         return json_response(response, headers=headers)
 
     async def get_node(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': {},
+            "code": 0,
+            "error_message": "",
+            "result": {},
         }
 
         try:
-            node_name = request.match_info['node']
+            node_name = request.match_info["node"]
             node = self.network.get_node_by_name(node_name)
-            response['result'] = {
-                'locator': node.locator_state,
-                'driver': node.driver.__class__.__name__,
-                'info': await node.get_info(),
+            response["result"] = {
+                "locator": node.locator_state,
+                "driver": node.driver.__class__.__name__,
+                "info": await node.get_info(),
             }
 
         except ValueError as e:
@@ -222,38 +211,36 @@ class LXAIOBusServer:
                 node_name,
             )
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         except Exception as e:
             logger.exception("get_node failed")
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': [],
+                "code": 1,
+                "error_message": str(e),
+                "result": [],
             }
 
-        headers = {
-            'Access-Control-Allow-Origin': '*'
-        }
+        headers = {"Access-Control-Allow-Origin": "*"}
 
         return json_response(response, headers=headers)
 
     async def get_pins(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': [],
+            "code": 0,
+            "error_message": "",
+            "result": [],
         }
 
         try:
-            node_name = request.match_info['node']
+            node_name = request.match_info["node"]
             node = self.network.get_node_by_name(node_name)
 
             for name, pin in node.driver.pins.items():
-                response['result'].append(name)
+                response["result"].append(name)
 
         except ValueError as e:
             logger.info(
@@ -261,39 +248,39 @@ class LXAIOBusServer:
                 node_name,
             )
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         except Exception as e:
             logger.exception("get_pins failed")
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': [],
+                "code": 1,
+                "error_message": str(e),
+                "result": [],
             }
 
         return Response(text=json.dumps(response))
 
     async def get_pin(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': None,
+            "code": 0,
+            "error_message": "",
+            "result": None,
         }
 
         try:
-            node_name = request.match_info['node']
-            pin_name = request.match_info['pin']
+            node_name = request.match_info["node"]
+            pin_name = request.match_info["pin"]
             node = self.network.get_node_by_name(node_name)
 
-            response['result'] = await node.driver.pins[pin_name].read()
+            response["result"] = await node.driver.pins[pin_name].read()
             logger.info(
-                    "get_pin: read pin %s on node %s: %s",
-                    pin_name,
-                    node_name,
-                    response['result'],
+                "get_pin: read pin %s on node %s: %s",
+                pin_name,
+                node_name,
+                response["result"],
             )
 
         except ValueError as e:
@@ -302,9 +289,9 @@ class LXAIOBusServer:
                 node_name,
             )
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         except KeyError as e:
@@ -314,120 +301,120 @@ class LXAIOBusServer:
                 node_name,
             )
             response = {
-                'code': 1,
-                'error_message': f"unknown pin '{pin_name}' for node '{node_name}'",
-                'result': None,
+                "code": 1,
+                "error_message": f"unknown pin '{pin_name}' for node '{node_name}'",
+                "result": None,
             }
 
         except Exception as e:
             logger.exception("get_pin failed")
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         return Response(text=json.dumps(response))
 
     async def get_pin_info(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': None,
+            "code": 0,
+            "error_message": "",
+            "result": None,
         }
 
         try:
-            node_name = request.match_info['node']
+            node_name = request.match_info["node"]
             node = self.network.get_node_by_name(node_name)
 
             pin_info = {
-                'locator': node.locator_state,
-                'inputs': {},
-                'outputs': {},
-                'adcs': {},
+                "locator": node.locator_state,
+                "inputs": {},
+                "outputs": {},
+                "adcs": {},
             }
 
             for pin_name, pin in node.driver.pins.items():
                 value = await pin.read()
 
-                if pin.pin_type == 'input':
-                    pin_info['inputs'][pin_name] = value
+                if pin.pin_type == "input":
+                    pin_info["inputs"][pin_name] = value
 
-                elif pin.pin_type == 'output':
-                    pin_info['outputs'][pin_name] = value
+                elif pin.pin_type == "output":
+                    pin_info["outputs"][pin_name] = value
 
-                elif pin.pin_type == 'adc':
-                    pin_info['adcs'][pin_name] = "{:.3f}".format(value)
+                elif pin.pin_type == "adc":
+                    pin_info["adcs"][pin_name] = "{:.3f}".format(value)
 
-            response['result'] = pin_info
+            response["result"] = pin_info
 
             # This view is polled by the web-interface.
             # To keep the log nice and clean we will only log this to debug.
             logger.debug(
-                    "get_pin_info: requested pin info for for node %s",
-                    node_name,
+                "get_pin_info: requested pin info for for node %s",
+                node_name,
             )
 
         except TimeoutError:
             response = {
-                'code': 1,
-                'error_message': 'timeout',
-                'result': None,
+                "code": 1,
+                "error_message": "timeout",
+                "result": None,
             }
 
         except ValueError:
             response = {
-                'code': 1,
-                'error_message': 'unknown node',
-                'result': None,
+                "code": 1,
+                "error_message": "unknown node",
+                "result": None,
             }
 
         except IndexError:
             response = {
-                'code': 1,
-                'error_message': 'unknown pin',
-                'result': None,
+                "code": 1,
+                "error_message": "unknown pin",
+                "result": None,
             }
 
         except Exception as e:
             logger.exception("get_pin_info failed")
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         return Response(text=json.dumps(response))
 
     async def set_pin(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': None,
+            "code": 0,
+            "error_message": "",
+            "result": None,
         }
 
         try:
-            node_name = request.match_info['node']
-            pin_name = request.match_info['pin']
+            node_name = request.match_info["node"]
+            pin_name = request.match_info["pin"]
             post = await request.post()
-            value = post['value']
+            value = post["value"]
 
             node = self.network.get_node_by_name(node_name)
             pin = node.driver.pins[pin_name]
 
-            if value == 'toggle':
+            if value == "toggle":
                 value = await pin.read()
                 value = 1 - value
 
             else:
                 value = int(value)
 
-            response['result'] = await pin.write(value)
+            response["result"] = await pin.write(value)
             logger.info(
-                    "set_pin: set pin %s on node %s to %s",
-                    pin_name,
-                    node_name,
-                    value,
+                "set_pin: set pin %s on node %s to %s",
+                pin_name,
+                node_name,
+                value,
             )
 
         except ValueError as e:
@@ -436,9 +423,9 @@ class LXAIOBusServer:
                 node_name,
             )
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         except KeyError as e:
@@ -448,30 +435,30 @@ class LXAIOBusServer:
                 node_name,
             )
             response = {
-                'code': 1,
-                'error_message': f"unknown pin '{pin_name}' for node '{node_name}'",
-                'result': None,
+                "code": 1,
+                "error_message": f"unknown pin '{pin_name}' for node '{node_name}'",
+                "result": None,
             }
 
         except Exception as e:
             logger.exception("set_pin failed")
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         return Response(text=json.dumps(response))
 
     async def toggle_locator(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': None,
+            "code": 0,
+            "error_message": "",
+            "result": None,
         }
 
         try:
-            node_name = request.match_info['node']
+            node_name = request.match_info["node"]
             node = self.network.get_node_by_name(node_name)
 
             # The locator state is updated by periodic pings
@@ -479,9 +466,9 @@ class LXAIOBusServer:
             new_state = not node.locator_state
             await node.set_locator_state(new_state)
             logger.info(
-                    "toggle_locator: set locator on node %s to %s",
-                    node_name,
-                    new_state,
+                "toggle_locator: set locator on node %s to %s",
+                node_name,
+                new_state,
             )
 
         except ValueError as e:
@@ -490,18 +477,18 @@ class LXAIOBusServer:
                 node_name,
             )
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         except Exception as e:
-            logger.exception('toggle locator failed')
+            logger.exception("toggle locator failed")
 
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         return Response(text=json.dumps(response))
@@ -516,163 +503,170 @@ class LXAIOBusServer:
 
         if self.allow_custom_firmware:
             for i in os.listdir(self.firmware_directory):
-                if i.startswith('.'):
+                if i.startswith("."):
                     continue
                 local_files.append(i)
 
         response = {
-            'upstream_files': upstream_files,
-            'local_files': local_files,
-            'allow_custom_firmware': self.allow_custom_firmware,
+            "upstream_files": upstream_files,
+            "local_files": local_files,
+            "allow_custom_firmware": self.allow_custom_firmware,
         }
 
         return Response(text=json.dumps(response))
 
     async def firmware_upload(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': None,
+            "code": 0,
+            "error_message": "",
+            "result": None,
         }
 
         if not self.allow_custom_firmware:
-            logger.exception('Firmware upload not possible if allow-custom-firmware is not set.')  # noqa
+            logger.exception("Firmware upload not possible if allow-custom-firmware is not set.")  # noqa
             response = {
-                'code': 1,
-                'error_message': 'Firmware upload not possible if allow-custom-firmware is not set.',  # noqa
-                'result': None,
+                "code": 1,
+                "error_message": "Firmware upload not possible if allow-custom-firmware is not set.",  # noqa
+                "result": None,
             }
             return Response(text=json.dumps(response))
 
         try:
             data = await request.post()
 
-            filename = data['file'].filename
-            file_content = data['file'].file.read()
+            filename = data["file"].filename
+            file_content = data["file"].file.read()
 
             abs_filename = os.path.join(self.firmware_directory, filename)
 
-            with open(abs_filename, 'wb+') as f:
+            with open(abs_filename, "wb+") as f:
                 f.write(file_content)
 
-            return HTTPFound('/#firmware-files')
+            return HTTPFound("/#firmware-files")
 
         except Exception as e:
-            logger.exception('firmware upload failed')
+            logger.exception("firmware upload failed")
 
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         return Response(text=json.dumps(response))
 
     async def firmware_delete(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': None,
+            "code": 0,
+            "error_message": "",
+            "result": None,
         }
 
         if not self.allow_custom_firmware:
-            logger.exception('Firmware delete not possible if allow-custom-firmware is not set.')  # noqa
+            logger.exception("Firmware delete not possible if allow-custom-firmware is not set.")  # noqa
             response = {
-                'code': 1,
-                'error_message': 'Firmware delete not possible if allow-custom-firmware is not set.',  # noqa
-                'result': None,
+                "code": 1,
+                "error_message": "Firmware delete not possible if allow-custom-firmware is not set.",  # noqa
+                "result": None,
             }
             return Response(text=json.dumps(response))
 
         try:
-            filename = os.path.join(self.firmware_directory,
-                                    request.match_info['file_name'])
+            filename = os.path.join(self.firmware_directory, request.match_info["file_name"])
 
             os.remove(filename)
 
         except Exception as e:
-            logger.exception('firmware delete failed')
+            logger.exception("firmware delete failed")
 
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         return Response(text=json.dumps(response))
 
     async def firmware_flash(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': None,
+            "code": 0,
+            "error_message": "",
+            "result": None,
         }
 
         if not self.allow_custom_firmware:
-            logger.exception('Custom firmware flashing not possible if allow-custom-firmware is not set.')  # noqa
+            logger.exception("Custom firmware flashing not possible if allow-custom-firmware is not set.")  # noqa
             response = {
-                'code': 1,
-                'error_message': 'Custom firmware flashing not possible if allow-custom-firmware is not set.',  # noqa
-                'result': None,
+                "code": 1,
+                "error_message": "Custom firmware flashing not possible if allow-custom-firmware is not set.",  # noqa
+                "result": None,
             }
             return Response(text=json.dumps(response))
 
         try:
-            node_name = request.match_info['node']
-            source = request.match_info['source']
-            file_name = request.match_info['file_name']
+            node_name = request.match_info["node"]
+            source = request.match_info["source"]
+            file_name = request.match_info["file_name"]
 
             node = self.network.get_node_by_name(node_name)
 
             # find firmware file
-            if source == 'local':
+            if source == "local":
                 file_name = os.path.join(self.firmware_directory, file_name)
 
-            elif source == 'upstream':
+            elif source == "upstream":
                 file_name = os.path.join(FIRMWARE_DIR, file_name)
 
             else:
-                raise ValueError('unknown mode')
+                raise ValueError("unknown mode")
 
             await self.flash_jobs.put(
-                (False, node, file_name, )
+                (
+                    False,
+                    node,
+                    file_name,
+                )
             )
 
         except Exception as e:
-            logger.exception('Firmware flashing failed')
+            logger.exception("Firmware flashing failed")
 
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         return Response(text=json.dumps(response))
 
     async def firmware_update(self, request):
         response = {
-            'code': 0,
-            'error_message': '',
-            'result': None,
+            "code": 0,
+            "error_message": "",
+            "result": None,
         }
 
         try:
-            node_name = request.match_info['node']
+            node_name = request.match_info["node"]
             node = self.network.get_node_by_name(node_name)
 
             file_name = FIRMWARE_VERSIONS[node.driver.__class__][1]
 
             await self.flash_jobs.put(
-                (False, node, file_name, )
+                (
+                    False,
+                    node,
+                    file_name,
+                )
             )
 
         except Exception as e:
-            logger.exception('Firmware update failed')
+            logger.exception("Firmware update failed")
 
             response = {
-                'code': 1,
-                'error_message': str(e),
-                'result': None,
+                "code": 1,
+                "error_message": str(e),
+                "result": None,
             }
 
         return Response(text=json.dumps(response))
@@ -695,23 +689,24 @@ class LXAIOBusServer:
                 node_info = await node.get_info()
 
             except Exception as e:
-                logger.warning("Exception during get_info() for node {}: {}".format(
-                    node, repr(e)))
+                logger.warning("Exception during get_info() for node {}: {}".format(node, repr(e)))
                 node_info = {}
 
-            state.append([
-                node.name, {
-                    'locator': node.locator_state,
-                    'driver': node_driver.__class__.__name__,
-                    'info': node_info,
-                },
-            ])
+            state.append(
+                [
+                    node.name,
+                    {
+                        "locator": node.locator_state,
+                        "driver": node_driver.__class__.__name__,
+                        "info": node_info,
+                    },
+                ]
+            )
 
-        await self.rpc.notify('state', state)
+        await self.rpc.notify("state", state)
 
     def flush_state_sync(self, wait=True):
-        self.rpc.worker_pool.run_sync(
-            partial(self.rpc.notify, 'state', pformat(self.state)), wait=wait)
+        self.rpc.worker_pool.run_sync(partial(self.rpc.notify, "state", pformat(self.state)), wait=wait)
 
     async def flush_state_periodicly(self):
         while self._running:

--- a/lxa_iobus/server/server.py
+++ b/lxa_iobus/server/server.py
@@ -22,7 +22,7 @@ logger = logging.getLogger("LXAIOBusServer")
 
 
 class LXAIOBusServer:
-    def __init__(self, app, loop, network, firmware_directory, allow_custom_firmware):  # noqa
+    def __init__(self, app, loop, network, firmware_directory, allow_custom_firmware):
         self.app = app
         self.loop = loop
         self.network = network
@@ -239,7 +239,7 @@ class LXAIOBusServer:
             node_name = request.match_info["node"]
             node = self.network.get_node_by_name(node_name)
 
-            for name, pin in node.driver.pins.items():
+            for name, _ in node.driver.pins.items():
                 response["result"].append(name)
 
         except ValueError as e:
@@ -294,7 +294,7 @@ class LXAIOBusServer:
                 "result": None,
             }
 
-        except KeyError as e:
+        except KeyError:
             logger.info(
                 "get_pin: user requested unknown pin '%s' from node '%s'.",
                 pin_name,
@@ -428,7 +428,7 @@ class LXAIOBusServer:
                 "result": None,
             }
 
-        except KeyError as e:
+        except KeyError:
             logger.info(
                 "set_pin: user wanted to set unknown pin '%s' on node '%s'.",
                 pin_name,
@@ -498,7 +498,7 @@ class LXAIOBusServer:
         upstream_files = []
         local_files = []
 
-        for driver, (version, path) in FIRMWARE_VERSIONS.items():
+        for _, (_, path) in FIRMWARE_VERSIONS.items():
             upstream_files.append(os.path.basename(path))
 
         if self.allow_custom_firmware:
@@ -523,10 +523,10 @@ class LXAIOBusServer:
         }
 
         if not self.allow_custom_firmware:
-            logger.exception("Firmware upload not possible if allow-custom-firmware is not set.")  # noqa
+            logger.exception("Firmware upload not possible if allow-custom-firmware is not set.")
             response = {
                 "code": 1,
-                "error_message": "Firmware upload not possible if allow-custom-firmware is not set.",  # noqa
+                "error_message": "Firmware upload not possible if allow-custom-firmware is not set.",
                 "result": None,
             }
             return Response(text=json.dumps(response))
@@ -563,10 +563,10 @@ class LXAIOBusServer:
         }
 
         if not self.allow_custom_firmware:
-            logger.exception("Firmware delete not possible if allow-custom-firmware is not set.")  # noqa
+            logger.exception("Firmware delete not possible if allow-custom-firmware is not set.")
             response = {
                 "code": 1,
-                "error_message": "Firmware delete not possible if allow-custom-firmware is not set.",  # noqa
+                "error_message": "Firmware delete not possible if allow-custom-firmware is not set.",
                 "result": None,
             }
             return Response(text=json.dumps(response))
@@ -595,10 +595,10 @@ class LXAIOBusServer:
         }
 
         if not self.allow_custom_firmware:
-            logger.exception("Custom firmware flashing not possible if allow-custom-firmware is not set.")  # noqa
+            logger.exception("Custom firmware flashing not possible if allow-custom-firmware is not set.")
             response = {
                 "code": 1,
-                "error_message": "Custom firmware flashing not possible if allow-custom-firmware is not set.",  # noqa
+                "error_message": "Custom firmware flashing not possible if allow-custom-firmware is not set.",
                 "result": None,
             }
             return Response(text=json.dumps(response))

--- a/lxa_iobus/server/static/index.html
+++ b/lxa_iobus/server/static/index.html
@@ -1,8 +1,8 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <link rel="stylesheet" type="text/css" href="/static/lib/pure-min.css">
-    <link rel="stylesheet" type="text/css" href="/static/style.css">
+    <link rel="stylesheet" type="text/css" href="/static/lib/pure-min.css" />
+    <link rel="stylesheet" type="text/css" href="/static/style.css" />
     <title>LXA IOBus Server</title>
   </head>
   <body>
@@ -12,7 +12,6 @@
       <div id="content">
         <div id="ractive"></div>
       </div>
-
     </div>
 
     <script id="main" type="text/html">
@@ -177,9 +176,10 @@
 
     <script id="isp" type="text/html">
       <h3>ISP Console</h3>
-      <pre>{{#isp_console}}{{.}}
-{{/}}</pre>
-
+      <pre>
+{{#isp_console}}{{.}}
+{{/}}</pre
+      >
     </script>
 
     <script id="firmware-files" type="text/html">
@@ -191,44 +191,52 @@
         </thead>
         <tbody>
           {{#firmware.upstream_files}}
-            <tr>
-              <td>{{.}}</td>
-            </tr>
+          <tr>
+            <td>{{.}}</td>
+          </tr>
           {{/}}
         </tbody>
       </table>
 
-      {{#if firmware.allow_custom_firmware}}
-        {{#if firmware.local_files}}
-          <br>
-          <table class="pure-table" width="100%">
-            <thead>
-              <tr>
-                <th>Local Firmware Files</th>
-              </tr>
-            </thead>
-            <tbody>
-              {{#firmware.local_files}}
-                <tr>
-                  <td>
-                    {{.}}
-                    <div class="pull-right">
-                      <button class="pure-button button-error" onclick="delete_firmware('{{.}}');">Delete</button>
-                    </div>
-                  </td>
-                </tr>
-              {{/}}
-            </tbody>
-          </table>
-        {{/if}}
-
-        <h3>Upload Firmware File</h3>
-        <form action="/firmware/upload/" method="post" accept-charset="utf-8" enctype="multipart/form-data">
-          <input id="file" name="file" type="file" />
-          <input type="submit" value="Upload" class="pure-button"/>
-        </form>
+      {{#if firmware.allow_custom_firmware}} {{#if firmware.local_files}}
+      <br />
+      <table class="pure-table" width="100%">
+        <thead>
+          <tr>
+            <th>Local Firmware Files</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#firmware.local_files}}
+          <tr>
+            <td>
+              {{.}}
+              <div class="pull-right">
+                <button
+                  class="pure-button button-error"
+                  onclick="delete_firmware('{{.}}');"
+                >
+                  Delete
+                </button>
+              </div>
+            </td>
+          </tr>
+          {{/}}
+        </tbody>
+      </table>
       {{/if}}
 
+      <h3>Upload Firmware File</h3>
+      <form
+        action="/firmware/upload/"
+        method="post"
+        accept-charset="utf-8"
+        enctype="multipart/form-data"
+      >
+        <input id="file" name="file" type="file" />
+        <input type="submit" value="Upload" class="pure-button" />
+      </form>
+      {{/if}}
     </script>
 
     <script src="/static/lib/jquery-3.5.1.min.js"></script>

--- a/lxa_iobus/server/static/main.js
+++ b/lxa_iobus/server/static/main.js
@@ -1,51 +1,63 @@
 // helper functions -----------------------------------------------------------
 function toggle_locator(node_address) {
-    $.post('/nodes/' + node_address + '/toggle-locator/');
+  $.post("/nodes/" + node_address + "/toggle-locator/");
 
-    update_pin_info();
-};
+  update_pin_info();
+}
 
 function toggle_pin(node_address, pin_name) {
-    $.post('/nodes/' + node_address + '/pins/' + pin_name + '/', {
-        value: 'toggle',
-    });
+  $.post("/nodes/" + node_address + "/pins/" + pin_name + "/", {
+    value: "toggle",
+  });
 
-    update_pin_info();
-};
+  update_pin_info();
+}
 
 function get_firmware_files() {
-    $.getJSON('/firmware/').done(function(data) {
-	ractive.set('firmware', data);
-    });
+  $.getJSON("/firmware/").done(function (data) {
+    ractive.set("firmware", data);
+  });
 }
 
 function flash_firmware(node_address, firmware) {
-    $.post('/nodes/' + node_address + '/flash-firmware/' + firmware, {});
-    ractive.set('template', 'isp');
-};
+  $.post("/nodes/" + node_address + "/flash-firmware/" + firmware, {});
+  ractive.set("template", "isp");
+}
 
 function update_node(node_address, firmware) {
-    $.post('/nodes/' + node_address + '/update/', {});
-    ractive.set('template', 'isp');
-};
+  $.post("/nodes/" + node_address + "/update/", {});
+  ractive.set("template", "isp");
+}
 
 function delete_firmware(filename) {
-    $.post('/firmware/delete/' + filename, {}).done(function() {
-	get_firmware_files()
-    });
-};
+  $.post("/firmware/delete/" + filename, {}).done(function () {
+    get_firmware_files();
+  });
+}
 
 // server info ----------------------------------------------------------------
 function update_info() {
-    $.getJSON('/server-info/').done(function(data) {
-        document.querySelector('#server-info-hostname').innerHTML = data['hostname'];
-        document.querySelector('#server-info-server-started').innerHTML = data['started'];
-        document.querySelector('#server-info-can-interface').innerHTML = data['can_interface'];
-        document.querySelector('#server-info-can-interface-state').innerHTML = data['can_interface_is_up'] ? 'UP' : 'DOWN';
-        document.querySelector('#server-info-can-tx-error').innerHTML = data['can_tx_error'] ? 'TX_ERROR!' : '';
-        document.querySelector('#server-info-lss-state').innerHTML = data['lss_state'];
-    });
-};
+  $.getJSON("/server-info/").done(function (data) {
+    document.querySelector("#server-info-hostname").innerHTML =
+      data["hostname"];
+    document.querySelector("#server-info-server-started").innerHTML =
+      data["started"];
+    document.querySelector("#server-info-can-interface").innerHTML =
+      data["can_interface"];
+    document.querySelector("#server-info-can-interface-state").innerHTML = data[
+      "can_interface_is_up"
+    ]
+      ? "UP"
+      : "DOWN";
+    document.querySelector("#server-info-can-tx-error").innerHTML = data[
+      "can_tx_error"
+    ]
+      ? "TX_ERROR!"
+      : "";
+    document.querySelector("#server-info-lss-state").innerHTML =
+      data["lss_state"];
+  });
+}
 
 setInterval(update_info, 1000);
 
@@ -53,106 +65,105 @@ setInterval(update_info, 1000);
 Ractive.DEBUG = false;
 
 var ractive = Ractive({
-    target: '#ractive',
-    template: '#main',
-    data: {
-        connected: true,
-        template: window.location.hash.substr(1) || 'nodes',
-        dots: [],
-        state: '',
+  target: "#ractive",
+  template: "#main",
+  data: {
+    connected: true,
+    template: window.location.hash.substr(1) || "nodes",
+    dots: [],
+    state: "",
+  },
+  computed: {
+    node_info: function () {
+      var selected_node = this.get("selected_node");
+      var state = this.get("state");
+
+      for (var i in this.get("state")) {
+        var node = state[i];
+
+        if (node[0] == selected_node) {
+          return node[1];
+        }
+      }
+
+      return {};
     },
-    computed: {
-        node_info: function() {
-            var selected_node = this.get('selected_node');
-            var state = this.get('state');
-
-            for(var i in this.get('state')) {
-                var node = state[i];
-
-                if(node[0] == selected_node) {
-                    return node[1];
-                };
-            };
-
-            return {};
-        },
-    },
+  },
 });
 
 // RPC ------------------------------------------------------------------------
-var rpc_protocol = 'ws://';
+var rpc_protocol = "ws://";
 
-if(window.location.protocol == 'https:') {
-    rpc_protocol = 'wss://';
+if (window.location.protocol == "https:") {
+  rpc_protocol = "wss://";
 }
 
-var rpc = new RPC(rpc_protocol + window.location.host + '/rpc/');
+var rpc = new RPC(rpc_protocol + window.location.host + "/rpc/");
 rpc.DEBUG = false;
 
 var first_connect = true;
 
-rpc.on('close', function(rpc) {
-    ractive.set('connected', false);
+rpc.on("close", function (rpc) {
+  ractive.set("connected", false);
 
-    setTimeout(function() {
-        var dots = ractive.get('dots');
-        dots.push('.');
+  setTimeout(function () {
+    var dots = ractive.get("dots");
+    dots.push(".");
 
-        if(dots.length >= 4) {
-            dots = [];
-        }
+    if (dots.length >= 4) {
+      dots = [];
+    }
 
-        ractive.set('dots', dots);
+    ractive.set("dots", dots);
 
-        rpc.connect();
-    }, 1000);
+    rpc.connect();
+  }, 1000);
 });
 
-rpc.on('open', function(rpc) {
-    if(first_connect) {
-        first_connect = false;
-    } else {
-        window.location.reload();
-    };
+rpc.on("open", function (rpc) {
+  if (first_connect) {
+    first_connect = false;
+  } else {
+    window.location.reload();
+  }
 
-    ractive.set({
-        connected: true,
-        state: '',
-    });
+  ractive.set({
+    connected: true,
+    state: "",
+  });
 
-    rpc._topic_handler.state = function(data) {
-        ractive.set('state', data);
-    };
+  rpc._topic_handler.state = function (data) {
+    ractive.set("state", data);
+  };
 
-    rpc._topic_handler.isp_console = function(data) {
-        ractive.set('isp_console', data);
-    };
+  rpc._topic_handler.isp_console = function (data) {
+    ractive.set("isp_console", data);
+  };
 
-    rpc.call('subscribe', 'state');
-    rpc.call('subscribe', 'isp_console');
+  rpc.call("subscribe", "state");
+  rpc.call("subscribe", "isp_console");
 });
 
 rpc.connect();
 
 function update_pin_info() {
-    if(!ractive.get('connected')) {
-        return;
-    };
+  if (!ractive.get("connected")) {
+    return;
+  }
 
-    var selected_node = ractive.get('selected_node');
+  var selected_node = ractive.get("selected_node");
 
-    if(!selected_node) {
-        return;
-    };
+  if (!selected_node) {
+    return;
+  }
 
-    $.getJSON('/nodes/' + selected_node + '/pin-info/').done(function(data) {
-        ractive.set('pin_info', data.result);
-    });
-
-};
+  $.getJSON("/nodes/" + selected_node + "/pin-info/").done(function (data) {
+    ractive.set("pin_info", data.result);
+  });
+}
 
 get_firmware_files();
 
-setInterval(function() {
-    update_pin_info();
+setInterval(function () {
+  update_pin_info();
 }, 1000);

--- a/lxa_iobus/server/static/style.css
+++ b/lxa_iobus/server/static/style.css
@@ -2,124 +2,124 @@
 .button-error,
 .button-warning,
 .button-secondary {
-    color: white;
-    border-radius: 4px;
-    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+  color: white;
+  border-radius: 4px;
+  text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
 }
 
 .button-success {
-    background: rgb(28, 184, 65);
-    /* this is a green */
+  background: rgb(28, 184, 65);
+  /* this is a green */
 }
 
 .button-error {
-    background: rgb(202, 60, 60);
-    /* this is a maroon */
+  background: rgb(202, 60, 60);
+  /* this is a maroon */
 }
 
 .button-warning {
-    background: rgb(223, 117, 20);
-    /* this is an orange */
+  background: rgb(223, 117, 20);
+  /* this is an orange */
 }
 
 .button-secondary {
-    background: rgb(66, 184, 221);
-    /* this is a light blue */
+  background: rgb(66, 184, 221);
+  /* this is a light blue */
 }
 
 .pull-right {
-	float: right;
+  float: right;
 }
 
 #main-grid,
 #content {
-    min-height: 100%;
+  min-height: 100%;
 }
 
 #main-grid {
-    display: grid;
-    grid-template-columns: auto 1000px auto;
-    grid-template-rows: 2em 5em auto;
+  display: grid;
+  grid-template-columns: auto 1000px auto;
+  grid-template-rows: 2em 5em auto;
 }
 
 #banner {
-    grid-column-start: 1;
-    grid-column-end: 4;
-    grid-row-start: 1;
-    grid-row-end: 3;
+  grid-column-start: 1;
+  grid-column-end: 4;
+  grid-row-start: 1;
+  grid-row-end: 3;
 
-    content: " ";
-    background-color: lightgrey;
-    border-bottom: 1px solid #999;
+  content: " ";
+  background-color: lightgrey;
+  border-bottom: 1px solid #999;
 }
 
 #content {
-    grid-column-start: 2;
-    grid-column-end: 2;
-    grid-row-start: 2;
-    grid-row-end: 4;
+  grid-column-start: 2;
+  grid-column-end: 2;
+  grid-row-start: 2;
+  grid-row-end: 4;
 
-    padding: 1em 0.5em;
-    background-color: white;
-    box-shadow: 0 0.25em 0.5em #777;
-    border: 1px solid #999;
-    border-bottom: 0px;
-    border-radius: 4px 4px 0px 0px;
+  padding: 1em 0.5em;
+  background-color: white;
+  box-shadow: 0 0.25em 0.5em #777;
+  border: 1px solid #999;
+  border-bottom: 0px;
+  border-radius: 4px 4px 0px 0px;
 }
 
 #template {
-    padding: 0.5em 1em;
+  padding: 0.5em 1em;
 }
 
 #content h1:first-child {
-    margin-top: 0;
+  margin-top: 0;
 }
 
 #content h1 {
-    padding-left: 0.5em;
+  padding-left: 0.5em;
 }
 
 .pure-menu {
-    height: 2em;
+  height: 2em;
 }
 
 .pure-menu-link {
-    background-color: transparent !important;
-    padding-right: 0;
+  background-color: transparent !important;
+  padding-right: 0;
 }
 
 #node-table tbody tr td:first-child {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 #node-table tbody tr {
-    color: black;
-    background-color: #d9ffcb;
+  color: black;
+  background-color: #d9ffcb;
 }
 
 #node-table tbody tr.locator_highlight {
-    color: white;
-    background-color: #5caa3e;
+  color: white;
+  background-color: #5caa3e;
 }
 
 #node-info-back {
-    font-weight: bold;
-    cursor: pointer;
+  font-weight: bold;
+  cursor: pointer;
 }
 
 #node-info {
-    margin-top: 0.75em;
+  margin-top: 0.75em;
 }
 
 #node-info tr {
-    text-align: left;
+  text-align: left;
 }
 
 #outputs button {
-    margin-right: 0.5em;
+  margin-right: 0.5em;
 }
 
 #server-info {
-    padding-left: 16px;
-    margin-bottom: 2em;
+  padding-left: 16px;
+  margin-bottom: 2em;
 }

--- a/lxa_iobus/utils.py
+++ b/lxa_iobus/utils.py
@@ -3,4 +3,4 @@ def array2int(a):
 
 
 def int2array(c, octets=4):
-    return list(((c >> (i * 8)) & 0xff) for i in range(octets))
+    return list(((c >> (i * 8)) & 0xFF) for i in range(octets))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 line-length = 119
 
 [tool.ruff.lint]
-select = ["B", "E", "F"]
+select = ["B", "E", "F", "I"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,4 +2,4 @@
 line-length = 119
 
 [tool.ruff.lint]
-select = ["B", "E", "F", "I"]
+select = ["B", "E", "F", "I", "SIM"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+line-length = 119

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,5 @@
 [tool.ruff]
 line-length = 119
+
+[tool.ruff.lint]
+select = ["B", "E", "F"]

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 import lxa_iobus
 

--- a/setup.py
+++ b/setup.py
@@ -6,35 +6,35 @@ from setuptools import setup, find_packages
 import lxa_iobus
 
 EXTRAS_REQUIRE = {
-    'server': [
-        'aiohttp~=3.8',
-        'aiohttp-json-rpc==0.13.3',
+    "server": [
+        "aiohttp~=3.8",
+        "aiohttp-json-rpc==0.13.3",
     ],
-    'shell': [
-        'ipython<7',
+    "shell": [
+        "ipython<7",
     ],
 }
 
-EXTRAS_REQUIRE['full'] = sum([v for k, v in EXTRAS_REQUIRE.items()], [])
+EXTRAS_REQUIRE["full"] = sum([v for k, v in EXTRAS_REQUIRE.items()], [])
 
 setup(
     include_package_data=True,
-    name='lxa-iobus',
+    name="lxa-iobus",
     version=lxa_iobus.VERSION_STRING,
-    author='Linux Automation GmbH',
-    url='https://github.com/linux-automation/lxa-iobus',
-    author_email='python@pengutronix.de',
-    license='Apache License 2.0',
+    author="Linux Automation GmbH",
+    url="https://github.com/linux-automation/lxa-iobus",
+    author_email="python@pengutronix.de",
+    license="Apache License 2.0",
     packages=find_packages(),
     install_requires=[
-        'python-can',
-        'janus',
+        "python-can",
+        "janus",
     ],
     extras_require=EXTRAS_REQUIRE,
     scripts=[
-        'bin/lxa-iobus-server',
-        'bin/lxa-iobus-can-setup',
-        'bin/lxa-iobus-lpc11xxcanisp-invoke',
-        'bin/lxa-iobus-lpc11xxcanisp-program',
+        "bin/lxa-iobus-server",
+        "bin/lxa-iobus-can-setup",
+        "bin/lxa-iobus-lpc11xxcanisp-invoke",
+        "bin/lxa-iobus-lpc11xxcanisp-program",
     ],
 )


### PR DESCRIPTION
This PR adds black, isort and prettier (auto formatters) and flake8 (python linter), as well as codespell to check for typos and fixes all issues that the various tools brought up.

TODO before merging:

  - [x] ~~This PR is now based on #34, which already added black and flake8. That PR should be merged first and then this one should be rebased on top of it.~~
        This PR is no longer based on #34, because it now uses `ruff` instead of `black` + `flake8` + `isort`, which has the benefit of having one tool and not three tools fighting about the question what python code should look like.