### PR TITLE
lxa_iobus: server: fix string/integer type confusion in set_pin()

### DIFF
--- a/lxa_iobus/server/server.py
+++ b/lxa_iobus/server/server.py
@@ -432,7 +432,7 @@ class LXAIOBusServer:
             if value == "toggle":
                 await node.od.outputs.toggle(pin_name)
 
-            elif value:
+            elif int(value):
                 await node.od.outputs.set_high(pin_name)
 
             else:


### PR DESCRIPTION
The form encoded parameter `value` sent via POST request is parsed by aiohttp so it can be used in set_pin().
It is however passed in as string ("0", "1" or "toggle") so it will always be considered true-ish, resulting in the current implementation always turning the output on, even if "0" was requested.

Treat the value as integer instead (as long as it is not "toggle") and check that for true-ish-ness.

Fixes: 9236c1d introduced in #38.

TODO before merging:

- [x] Check if other form data handling in `server.py` is sound. ~~It is unclear why this worked previously, because there was no type conversion in the code that 9236c1d replaced.~~ There was a type conversion. I just overlooked it in the diff.