### PR TITLE
CI: add automatic publication to pypi.org and test.pypi.org

### DIFF
--- a/.github/workflows/check-and-publish.yaml
+++ b/.github/workflows/check-and-publish.yaml
@@ -1,4 +1,4 @@
-name: Check and Build
+name: Check and Publish
 
 on: [push, pull_request]
 
@@ -40,3 +40,28 @@ jobs:
         with:
           name: dist
           path: dist
+
+  publish:
+    name: Publish
+    if: ${{ github.event_name == 'push' && vars.PUBLISH_PYPI == 'true' && (startsWith(github.ref, 'refs/tags') || github.ref == 'refs/heads/master') }}
+    runs-on: ubuntu-latest
+    needs:
+      - codespell
+      - prettier
+      - ruff
+      - build
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts from build stage
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish distribution package to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+      - name: Publish distribution package to PyPI
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/Makefile
+++ b/Makefile
@@ -37,10 +37,10 @@ $(PYTHON_PACKAGING_VENV)/.created:
 	$(PYTHON) -m venv $(PYTHON_PACKAGING_VENV) && \
 	. $(PYTHON_PACKAGING_VENV)/bin/activate && \
 	python3 -m pip install --upgrade pip && \
-	python3 -m pip install build twine && \
+	python3 -m pip install build && \
 	date > $(PYTHON_PACKAGING_VENV)/.created
 
-.PHONY: packaging-env build _release
+.PHONY: packaging-env build
 
 packaging-env: $(PYTHON_PACKAGING_VENV)/.created
 
@@ -48,10 +48,6 @@ build: packaging-env
 	. $(PYTHON_PACKAGING_VENV)/bin/activate && \
 	rm -rf dist *.egg-info && \
 	python3 -m build
-
-_release: build
-	. $(PYTHON_PACKAGING_VENV)/bin/activate && \
-	twine upload dist/*
 
 # testing #####################################################################
 $(PYTHON_TESTING_ENV)/.created:


### PR DESCRIPTION
Publishing software manually is a (somewhat) error-prone and (somewhat) tedious process, hence why other projects have already automated this process.

Let's join these other projects and also automate our publication process!

The setup process is surprisingly straight forward and involves setting up trusted publishing on _both_ pypi.org, as well as test.pypi.org for the lxa-iobus project:

![pypi-auto](https://github.com/linux-automation/lxa-iobus/assets/1273320/01a331de-97f3-48cd-981e-7412e01eeede)

And setting a GitHub Action Variable that enables publication (so that the job does not run *and fail* for forked repositories by default):

![github-variable](https://github.com/linux-automation/lxa-iobus/assets/1273320/446220de-3f86-4c09-bdf0-f7b02c840f65)

TODO before merging:

- [x] This PR is based on #44, which enables automatic version number generation from git tags
- [x] and PR #45 which prepares the CI jobs for this PR.

Both of these PRs should be merged before this one.