### PR TITLE
node: object_directory: fix "these" typo in a comment

### DIFF
--- a/lxa_iobus/node/object_directory.py
+++ b/lxa_iobus/node/object_directory.py
@@ -795,7 +795,7 @@ class Locator(ProcessDataObject):
 class Adc(ProcessDataObject):
     """Read analog voltages on the node
 
-    The node contains the required calibration data to convert thease measurements
+    The node contains the required calibration data to convert these measurements
     to e.g. volts.
     """
 


### PR DESCRIPTION
The `codespell` tool has learned a few new common typos and this is one of them. Fix it to make our CI happy again.

This came up due to a failed CI run in #48 [here](https://github.com/linux-automation/lxa-iobus/actions/runs/9662697572/job/26653148370?pr=48).